### PR TITLE
Add strict types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   where possible. Some methods return mixed type so docblocks are still used.
 - Add type definitions docblocks for `Collection::sendToAll()` callbacks.
   There is no change to functionality, but this better explains how these work.
+### Fixed
+- `Pool::ignore()` incorrectly updated its own cache of watched tubes, meaning
+  multiple calls may have had unexpected results.
 ### Changed
 - **BC break**: Split `Command\Peek(<string>)` to `Command\PeekStatus`.
   `Command\Peek` now only accepts a Job ID integer. Will not impact standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Type declarations have been added to all method parameters and return types
+  where possible. Some methods return mixed type so docblocks are still used.
 - Add type definitions docblocks for `Collection::sendToAll()` callbacks.
   There is no change to functionality, but this better explains how these work.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- **BC break**: Restrict `Collection::send*` methods to only accept commands
+  defined in `ConnectionInterface`, rather than allowing any method to be called
+  on the connection.
 - Order of stats in `server:stats` CLI command to match order from Beanstalkd.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v7.3 as they are no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add type definitions docblocks for `Collection::sendToAll()` callbacks.
   There is no change to functionality, but this better explains how these work.
 ### Changed
+- **BC break**: Split `Command\Peek(<string>)` to `Command\PeekStatus`.
+  `Command\Peek` now only accepts a Job ID integer. Will not impact standard
+  implementations which directly use the `Connection::peek*` methods.
+  `Command\Peek` status constants are now on `Command\PeekStatus`.
 - **BC break**: Restrict `Collection::send*` methods to only accept commands
   defined in `ConnectionInterface`, rather than allowing any method to be called
   on the connection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add type definitions docblocks for `Collection::sendToAll()` callbacks.
+  There is no change to functionality, but this better explains how these work.
 ### Changed
 - **BC break**: Restrict `Collection::send*` methods to only accept commands
   defined in `ConnectionInterface`, rather than allowing any method to be called

--- a/bin/beanstalk
+++ b/bin/beanstalk
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+declare(strict_types=1);
+
 // autoload
 $autoloadFiles = [__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php'];
 foreach ($autoloadFiles as $autoloadFile) {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7",
-        "php-mock/php-mock-phpunit": "^2"
+        "php-mock/php-mock-phpunit": "^2",
+        "symplify/easy-coding-standard": "^9"
     },
     "autoload": {
         "psr-4": {
@@ -36,5 +37,9 @@
             "Phlib\\Beanstalk\\": "tests/"
         }
     },
-    "bin": ["bin/beanstalk"]
+    "bin": ["bin/beanstalk"],
+    "scripts": {
+        "cs-check": "vendor/bin/ecs",
+        "cs-fix": "vendor/bin/ecs --fix"
+    }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/bin',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    $containerConfigurator->import(SetList::COMMON);
+    // Remove sniff, from common/control-structures
+    $services->remove(\PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class);
+    // Remove sniff, from common/spaces
+    $services->remove(\PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class);
+
+    $containerConfigurator->import(SetList::PSR_12);
+};

--- a/src/Command/Bury.php
+++ b/src/Command/Bury.php
@@ -3,8 +3,8 @@
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\ValidateTrait;
 
 /**
@@ -34,7 +34,7 @@ class Bury implements CommandInterface
     {
         $this->validatePriority($priority);
 
-        $this->id       = $id;
+        $this->id = $id;
         $this->priority = $priority;
     }
 
@@ -47,7 +47,6 @@ class Bury implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return $this
      * @throws NotFoundException
      * @throws CommandException
@@ -62,10 +61,10 @@ class Bury implements CommandInterface
                 return $this;
 
             case 'NOT_FOUND':
-                throw new NotFoundException("Job id '$this->id' could not be found.");
+                throw new NotFoundException("Job id '{$this->id}' could not be found.");
 
             default:
-                throw new CommandException("Bury id '$this->id' failed '$response'");
+                throw new CommandException("Bury id '{$this->id}' failed '{$response}'");
         }
     }
 }

--- a/src/Command/Bury.php
+++ b/src/Command/Bury.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -17,20 +19,16 @@ class Bury implements CommandInterface
     use ToStringTrait;
 
     /**
-     * @var string|integer
+     * @var string|int
      */
     protected $id;
 
-    /**
-     * @var integer
-     */
-    protected $priority;
+    protected int $priority;
 
     /**
-     * @param string|integer $id
-     * @param integer        $priority
+     * @param string|int $id
      */
-    public function __construct($id, $priority)
+    public function __construct($id, int $priority)
     {
         $this->validatePriority($priority);
 
@@ -38,20 +36,12 @@ class Bury implements CommandInterface
         $this->priority = $priority;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('bury %d %d', $this->id, $this->priority);
     }
 
-    /**
-     * @return $this
-     * @throws NotFoundException
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): self
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -10,10 +12,7 @@ use Phlib\Beanstalk\Connection\SocketInterface;
  */
 interface CommandInterface
 {
-    /**
-     * @return string
-     */
-    public function getCommand();
+    public function getCommand(): string;
 
     /**
      * @return mixed

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -16,7 +16,6 @@ interface CommandInterface
     public function getCommand();
 
     /**
-     * @param SocketInterface $socket
      * @return mixed
      */
     public function process(SocketInterface $socket);

--- a/src/Command/Delete.php
+++ b/src/Command/Delete.php
@@ -3,8 +3,8 @@
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 
 /**
  * Class Delete
@@ -36,7 +36,6 @@ class Delete implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return $this
      * @throws NotFoundException
      * @throws CommandException
@@ -54,7 +53,7 @@ class Delete implements CommandInterface
                 throw new NotFoundException("Job id '{$this->id}' could not be found.");
 
             default:
-                throw new CommandException("Delete id '{$this->id}' failed '$response'");
+                throw new CommandException("Delete id '{$this->id}' failed '{$response}'");
         }
     }
 }

--- a/src/Command/Delete.php
+++ b/src/Command/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -15,32 +17,24 @@ class Delete implements CommandInterface
     use ToStringTrait;
 
     /**
-     * @var string|integer
+     * @var string|int
      */
     protected $id;
 
     /**
-     * @param string|integer $id
+     * @param string|int $id
      */
     public function __construct($id)
     {
         $this->id = $id;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('delete %d', $this->id);
     }
 
-    /**
-     * @return $this
-     * @throws NotFoundException
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): self
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/Ignore.php
+++ b/src/Command/Ignore.php
@@ -38,7 +38,6 @@ class Ignore implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return integer
      * @throws CommandException
      */
@@ -55,7 +54,7 @@ class Ignore implements CommandInterface
                 throw new CommandException('Can not ignore only tube currently watching.');
 
             default:
-                throw new CommandException("Ignore tube '$this->tube' failed '$status'");
+                throw new CommandException("Ignore tube '{$this->tube}' failed '{$status}'");
         }
     }
 }

--- a/src/Command/Ignore.php
+++ b/src/Command/Ignore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -15,33 +17,20 @@ class Ignore implements CommandInterface
     use ValidateTrait;
     use ToStringTrait;
 
-    /**
-     * @var string
-     */
-    protected $tube;
+    protected string $tube;
 
-    /**
-     * @param string $tube
-     */
-    public function __construct($tube)
+    public function __construct(string $tube)
     {
         $this->validateTubeName($tube);
         $this->tube = $tube;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('ignore %s', $this->tube);
     }
 
-    /**
-     * @return integer
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): int
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/Kick.php
+++ b/src/Command/Kick.php
@@ -35,7 +35,6 @@ class Kick implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return integer
      * @throws CommandException
      */
@@ -48,7 +47,7 @@ class Kick implements CommandInterface
                 return (int)strtok(' ');
 
             default:
-                throw new CommandException("Kick with bound '$this->bound' failed '$status'");
+                throw new CommandException("Kick with bound '{$this->bound}' failed '{$status}'");
         }
     }
 }

--- a/src/Command/Kick.php
+++ b/src/Command/Kick.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -13,32 +15,19 @@ class Kick implements CommandInterface
 {
     use ToStringTrait;
 
-    /**
-     * @var integer
-     */
-    protected $bound;
+    protected int $bound;
 
-    /**
-     * @param integer $bound
-     */
-    public function __construct($bound)
+    public function __construct(int $bound)
     {
         $this->bound = $bound;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('kick %d', $this->bound);
     }
 
-    /**
-     * @return integer
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): int
     {
         $socket->write($this->getCommand());
         $status = strtok($socket->read(), ' ');

--- a/src/Command/ListTubeUsed.php
+++ b/src/Command/ListTubeUsed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -13,19 +15,12 @@ class ListTubeUsed implements CommandInterface
 {
     use ToStringTrait;
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return 'list-tube-used';
     }
 
-    /**
-     * @return string
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): string
     {
         $socket->write('list-tube-used');
         $status = strtok($socket->read(), ' ');

--- a/src/Command/ListTubeUsed.php
+++ b/src/Command/ListTubeUsed.php
@@ -22,7 +22,6 @@ class ListTubeUsed implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return string
      * @throws CommandException
      */
@@ -35,7 +34,7 @@ class ListTubeUsed implements CommandInterface
                 return strtok(' ');
 
             default:
-                throw new CommandException("List tube used failed '$status'");
+                throw new CommandException("List tube used failed '{$status}'");
         }
     }
 }

--- a/src/Command/ListTubes.php
+++ b/src/Command/ListTubes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 /**
@@ -11,10 +13,7 @@ class ListTubes implements CommandInterface
     use StatsTrait;
     use ToStringTrait;
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return 'list-tubes';
     }

--- a/src/Command/ListTubesWatched.php
+++ b/src/Command/ListTubesWatched.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 /**
@@ -11,10 +13,7 @@ class ListTubesWatched implements CommandInterface
     use StatsTrait;
     use ToStringTrait;
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return 'list-tubes-watched';
     }

--- a/src/Command/Peek.php
+++ b/src/Command/Peek.php
@@ -6,7 +6,6 @@ namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
 use Phlib\Beanstalk\Exception\CommandException;
-use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use Phlib\Beanstalk\Exception\NotFoundException;
 
 /**
@@ -29,12 +28,7 @@ class Peek implements CommandInterface
         return sprintf('peek %u', $this->jobId);
     }
 
-    /**
-     * @return array
-     * @throws NotFoundException
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): array
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/Peek.php
+++ b/src/Command/Peek.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -15,54 +17,16 @@ class Peek implements CommandInterface
 {
     use ToStringTrait;
 
-    public const READY = 'ready';
+    protected int $jobId;
 
-    public const DELAYED = 'delayed';
-
-    public const BURIED = 'buried';
-
-    /**
-     * @var string|integer
-     */
-    protected $jobId = null;
-
-    /**
-     * @var string
-     */
-    protected $subCommand = null;
-
-    /**
-     * @var array
-     */
-    protected $subCommands = [
-        self::READY,
-        self::DELAYED,
-        self::BURIED,
-    ];
-
-    /**
-     * @param string $subject
-     * @throws InvalidArgumentException
-     */
-    public function __construct($subject)
+    public function __construct(int $jobId)
     {
-        if (is_int($subject) || ctype_digit($subject)) {
-            $this->jobId = $subject;
-        } elseif (in_array($subject, $this->subCommands)) {
-            $this->subCommand = $subject;
-        } else {
-            throw new InvalidArgumentException(sprintf('Invalid peek subject: %s', $subject));
-        }
+        $this->jobId = $jobId;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
-        return isset($this->jobId) ?
-            sprintf('peek %u', $this->jobId) :
-            sprintf('peek-%s', $this->subCommand);
+        return sprintf('peek %u', $this->jobId);
     }
 
     /**

--- a/src/Command/Peek.php
+++ b/src/Command/Peek.php
@@ -3,9 +3,9 @@
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
+use Phlib\Beanstalk\Exception\CommandException;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use Phlib\Beanstalk\Exception\NotFoundException;
-use Phlib\Beanstalk\Exception\CommandException;
 
 /**
  * Class Peek
@@ -15,9 +15,11 @@ class Peek implements CommandInterface
 {
     use ToStringTrait;
 
-    const READY   = 'ready';
-    const DELAYED = 'delayed';
-    const BURIED  = 'buried';
+    public const READY = 'ready';
+
+    public const DELAYED = 'delayed';
+
+    public const BURIED = 'buried';
 
     /**
      * @var string|integer
@@ -35,7 +37,7 @@ class Peek implements CommandInterface
     protected $subCommands = [
         self::READY,
         self::DELAYED,
-        self::BURIED
+        self::BURIED,
     ];
 
     /**
@@ -64,7 +66,6 @@ class Peek implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return array
      * @throws NotFoundException
      * @throws CommandException
@@ -76,17 +77,20 @@ class Peek implements CommandInterface
         $response = strtok($socket->read(), ' ');
         switch ($response) {
             case 'FOUND':
-                $id     = (int)strtok(' ');
-                $bytes  = (int)strtok(' ');
-                $body   = substr($socket->read($bytes + 2), 0, -2);
+                $id = (int)strtok(' ');
+                $bytes = (int)strtok(' ');
+                $body = substr($socket->read($bytes + 2), 0, -2);
 
-                return ['id' => $id, 'body' => $body];
+                return [
+                    'id' => $id,
+                    'body' => $body,
+                ];
 
             case 'NOT_FOUND':
-                throw new NotFoundException("Peek failed to find any jobs");
+                throw new NotFoundException('Peek failed to find any jobs');
 
             default:
-                throw new CommandException("Unknown peek response '$response'");
+                throw new CommandException("Unknown peek response '{$response}'");
         }
     }
 }

--- a/src/Command/PeekStatus.php
+++ b/src/Command/PeekStatus.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\Beanstalk\Command;
+
+use Phlib\Beanstalk\Exception\InvalidArgumentException;
+
+/**
+ * @package Phlib\Beanstalk\Command
+ */
+class PeekStatus extends Peek
+{
+    use ToStringTrait;
+
+    public const READY = 'ready';
+
+    public const DELAYED = 'delayed';
+
+    public const BURIED = 'buried';
+
+    private const ALLOWED_STATUS = [
+        self::READY,
+        self::DELAYED,
+        self::BURIED,
+    ];
+
+    protected string $status;
+
+    public function __construct(string $status)
+    {
+        if (!in_array($status, self::ALLOWED_STATUS, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid peek subject: %s', $status));
+        }
+        $this->status = $status;
+    }
+
+    public function getCommand(): string
+    {
+        return sprintf('peek-%s', $this->status);
+    }
+}

--- a/src/Command/Put.php
+++ b/src/Command/Put.php
@@ -46,10 +46,10 @@ class Put implements CommandInterface
         $this->validateJobData($data);
         $this->validatePriority($priority);
 
-        $this->data     = (string)$data;
+        $this->data = (string)$data;
         $this->priority = $priority;
-        $this->delay    = $delay;
-        $this->ttr      = $ttr;
+        $this->delay = $delay;
+        $this->ttr = $ttr;
     }
 
     /**
@@ -62,7 +62,6 @@ class Put implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return integer
      * @throws CommandException
      */
@@ -81,7 +80,7 @@ class Put implements CommandInterface
             case 'JOB_TOO_BIG':
             case 'DRAINING':
             default:
-                throw new CommandException("Put failed '$status'");
+                throw new CommandException("Put failed '{$status}'");
         }
     }
 }

--- a/src/Command/Put.php
+++ b/src/Command/Put.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -15,33 +17,15 @@ class Put implements CommandInterface
     use ValidateTrait;
     use ToStringTrait;
 
-    /**
-     * @var string
-     */
-    protected $data;
+    protected string $data;
 
-    /**
-     * @var integer
-     */
-    protected $priority;
+    protected int $priority;
 
-    /**
-     * @var integer
-     */
-    protected $delay;
+    protected int $delay;
 
-    /**
-     * @var integer
-     */
-    protected $ttr;
+    protected int $ttr;
 
-    /**
-     * @param string  $data
-     * @param integer $priority
-     * @param integer $delay
-     * @param integer $ttr
-     */
-    public function __construct($data, $priority, $delay, $ttr)
+    public function __construct(string $data, int $priority, int $delay, int $ttr)
     {
         $this->validateJobData($data);
         $this->validatePriority($priority);
@@ -52,20 +36,13 @@ class Put implements CommandInterface
         $this->ttr = $ttr;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         $bytesSent = strlen($this->data);
         return sprintf('put %d %d %d %d', $this->priority, $this->delay, $this->ttr, $bytesSent);
     }
 
-    /**
-     * @return integer
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): int
     {
         $socket->write($this->getCommand());
         $socket->write($this->data);

--- a/src/Command/Release.php
+++ b/src/Command/Release.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -16,27 +18,13 @@ class Release implements CommandInterface
     use ValidateTrait;
     use ToStringTrait;
 
-    /**
-     * @var string|integer
-     */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @var integer
-     */
-    protected $priority;
+    protected int $priority;
 
-    /**
-     * @var integer
-     */
-    protected $delay;
+    protected int $delay;
 
-    /**
-     * @param string  $id
-     * @param integer $priority
-     * @param integer $delay
-     */
-    public function __construct($id, $priority, $delay)
+    public function __construct(int $id, int $priority, int $delay)
     {
         $this->validatePriority($priority);
 
@@ -45,20 +33,12 @@ class Release implements CommandInterface
         $this->delay = $delay;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('release %d %d %d', $this->id, $this->priority, $this->delay);
     }
 
-    /**
-     * @return $this
-     * @throws NotFoundException
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): self
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/Release.php
+++ b/src/Command/Release.php
@@ -3,8 +3,8 @@
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\ValidateTrait;
 
 /**
@@ -40,9 +40,9 @@ class Release implements CommandInterface
     {
         $this->validatePriority($priority);
 
-        $this->id       = $id;
+        $this->id = $id;
         $this->priority = $priority;
-        $this->delay    = $delay;
+        $this->delay = $delay;
     }
 
     /**
@@ -54,7 +54,6 @@ class Release implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return $this
      * @throws NotFoundException
      * @throws CommandException
@@ -70,10 +69,10 @@ class Release implements CommandInterface
                 return $this;
 
             case 'NOT_FOUND':
-                throw new NotFoundException("Job id '$this->id' could not be found.");
+                throw new NotFoundException("Job id '{$this->id}' could not be found.");
 
             default:
-                throw new CommandException("Release '$this->id' failed '$response'");
+                throw new CommandException("Release '{$this->id}' failed '{$response}'");
         }
     }
 }

--- a/src/Command/Reserve.php
+++ b/src/Command/Reserve.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -13,23 +15,14 @@ class Reserve implements CommandInterface
 {
     use ToStringTrait;
 
-    /**
-     * @var integer|null
-     */
-    protected $timeout;
+    protected ?int $timeout;
 
-    /**
-     * @param integer|null $timeout
-     */
-    public function __construct($timeout = null)
+    public function __construct(?int $timeout = null)
     {
         $this->timeout = $timeout;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         if ($this->timeout === null) {
             return 'reserve';
@@ -40,7 +33,6 @@ class Reserve implements CommandInterface
 
     /**
      * @return array|false
-     * @throws CommandException
      */
     public function process(SocketInterface $socket)
     {

--- a/src/Command/Reserve.php
+++ b/src/Command/Reserve.php
@@ -31,15 +31,14 @@ class Reserve implements CommandInterface
      */
     public function getCommand()
     {
-        if (is_null($this->timeout)) {
+        if ($this->timeout === null) {
             return 'reserve';
-        } else {
-            return sprintf('reserve-with-timeout %d', $this->timeout);
         }
+
+        return sprintf('reserve-with-timeout %d', $this->timeout);
     }
 
     /**
-     * @param SocketInterface $socket
      * @return array|false
      * @throws CommandException
      */
@@ -49,18 +48,21 @@ class Reserve implements CommandInterface
         $status = strtok($socket->read(), ' ');
         switch ($status) {
             case 'RESERVED':
-                $id     = (int)strtok(' ');
-                $bytes  = (int)strtok(' ');
-                $body   = substr($socket->read($bytes + 2), 0, -2);
+                $id = (int)strtok(' ');
+                $bytes = (int)strtok(' ');
+                $body = substr($socket->read($bytes + 2), 0, -2);
 
-                return ['id' => $id, 'body' => $body];
+                return [
+                    'id' => $id,
+                    'body' => $body,
+                ];
 
             case 'DEADLINE_SOON':
             case 'TIMED_OUT':
                 return false;
 
             default:
-                throw new CommandException("Reserve failed '$status'");
+                throw new CommandException("Reserve failed '{$status}'");
         }
     }
 }

--- a/src/Command/Stats.php
+++ b/src/Command/Stats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 /**
@@ -11,10 +13,7 @@ class Stats implements CommandInterface
     use StatsTrait;
     use ToStringTrait;
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return 'stats';
     }

--- a/src/Command/StatsJob.php
+++ b/src/Command/StatsJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 /**
@@ -12,22 +14,19 @@ class StatsJob implements CommandInterface
     use ToStringTrait;
 
     /**
-     * @var string|integer
+     * @var string|int
      */
     protected $id;
 
     /**
-     * @param integer|string $id
+     * @param int|string $id
      */
     public function __construct($id)
     {
         $this->id = $id;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('stats-job %d', $this->id);
     }

--- a/src/Command/StatsTrait.php
+++ b/src/Command/StatsTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -12,12 +14,7 @@ use Phlib\Beanstalk\Exception\NotFoundException;
  */
 trait StatsTrait
 {
-    /**
-     * @return array
-     * @throws NotFoundException
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): array
     {
         $socket->write($this->getCommand());
         $status = strtok($socket->read(), ' ');
@@ -36,11 +33,8 @@ trait StatsTrait
 
     /**
      * Decodes the YAML string into an array of data.
-     *
-     * @param  string $response
-     * @return array
      */
-    protected function decode($response)
+    protected function decode(string $response): array
     {
         $lines = array_slice(explode("\n", trim($response)), 1);
 

--- a/src/Command/StatsTrait.php
+++ b/src/Command/StatsTrait.php
@@ -40,7 +40,7 @@ trait StatsTrait
 
         $result = [];
         foreach ($lines as $line) {
-            if ($line[0] == '-') {
+            if ($line[0] === '-') {
                 $result[] = trim(ltrim($line, '- '));
             } else {
                 $key = strtok($line, ': ');

--- a/src/Command/StatsTrait.php
+++ b/src/Command/StatsTrait.php
@@ -41,7 +41,13 @@ trait StatsTrait
         $result = [];
         foreach ($lines as $line) {
             if ($line[0] === '-') {
-                $result[] = trim(ltrim($line, '- '));
+                $value = trim(ltrim($line, '- '));
+
+                if (is_numeric($value)) {
+                    $value = $value + 0;
+                }
+
+                $result[] = $value;
             } else {
                 $key = strtok($line, ': ');
                 if ($key) {

--- a/src/Command/StatsTrait.php
+++ b/src/Command/StatsTrait.php
@@ -3,8 +3,8 @@
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 
 /**
  * Class AbstractStats
@@ -12,9 +12,7 @@ use Phlib\Beanstalk\Exception\CommandException;
  */
 trait StatsTrait
 {
-
     /**
-     * @param SocketInterface $socket
      * @return array
      * @throws NotFoundException
      * @throws CommandException
@@ -29,10 +27,10 @@ trait StatsTrait
                 return $this->decode($data);
 
             case 'NOT_FOUND':
-                throw new NotFoundException("Stats read could not find specified job");
+                throw new NotFoundException('Stats read could not find specified job');
 
             default:
-                throw new CommandException("Stats read failed '$status'");
+                throw new CommandException("Stats read failed '{$status}'");
         }
     }
 

--- a/src/Command/StatsTube.php
+++ b/src/Command/StatsTube.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\ValidateTrait;
@@ -14,24 +16,15 @@ class StatsTube implements CommandInterface
     use ValidateTrait;
     use ToStringTrait;
 
-    /**
-     * @var string
-     */
-    protected $tube;
+    protected string $tube;
 
-    /**
-     * @param string $tube
-     */
-    public function __construct($tube)
+    public function __construct(string $tube)
     {
         $this->validateTubeName($tube);
         $this->tube = $tube;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('stats-tube %s', $this->tube);
     }

--- a/src/Command/ToStringTrait.php
+++ b/src/Command/ToStringTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 /**

--- a/src/Command/Touch.php
+++ b/src/Command/Touch.php
@@ -3,8 +3,8 @@
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 
 /**
  * Class Touch
@@ -36,7 +36,6 @@ class Touch implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return $this
      * @throws NotFoundException
      * @throws CommandException
@@ -51,10 +50,10 @@ class Touch implements CommandInterface
                 return $this;
 
             case 'NOT_TOUCHED':
-                throw new NotFoundException("Job id '$this->id' could not be found.");
+                throw new NotFoundException("Job id '{$this->id}' could not be found.");
 
             default:
-                throw new CommandException("Touch id '$this->id' failed '$status'");
+                throw new CommandException("Touch id '{$this->id}' failed '{$status}'");
         }
     }
 }

--- a/src/Command/Touch.php
+++ b/src/Command/Touch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -14,33 +16,19 @@ class Touch implements CommandInterface
 {
     use ToStringTrait;
 
-    /**
-     * @var string|integer
-     */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @param string $id
-     */
-    public function __construct($id)
+    public function __construct(int $id)
     {
         $this->id = $id;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('touch %d', $this->id);
     }
 
-    /**
-     * @return $this
-     * @throws NotFoundException
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): self
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/UseTube.php
+++ b/src/Command/UseTube.php
@@ -38,7 +38,6 @@ class UseTube implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return string
      * @throws CommandException
      */
@@ -51,7 +50,7 @@ class UseTube implements CommandInterface
             case 'USING':
                 return strtok(' '); // tube name
             default:
-                throw new CommandException("Use tube '$this->tube' failed '$status'");
+                throw new CommandException("Use tube '{$this->tube}' failed '{$status}'");
         }
     }
 }

--- a/src/Command/UseTube.php
+++ b/src/Command/UseTube.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -15,33 +17,20 @@ class UseTube implements CommandInterface
     use ValidateTrait;
     use ToStringTrait;
 
-    /**
-     * @var string
-     */
-    protected $tube;
+    protected string $tube;
 
-    /**
-     * @param string $tube
-     */
-    public function __construct($tube)
+    public function __construct(string $tube)
     {
         $this->validateTubeName($tube);
         $this->tube = $tube;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('use %s', $this->tube);
     }
 
-    /**
-     * @return string
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): string
     {
         $socket->write($this->getCommand());
 

--- a/src/Command/Watch.php
+++ b/src/Command/Watch.php
@@ -38,7 +38,6 @@ class Watch implements CommandInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return integer
      * @throws CommandException
      */
@@ -52,7 +51,7 @@ class Watch implements CommandInterface
                 return (int)strtok(' ');
 
             default:
-                throw new CommandException("Watch tube '$this->tube' failed '$status'");
+                throw new CommandException("Watch tube '{$this->tube}' failed '{$status}'");
         }
     }
 }

--- a/src/Command/Watch.php
+++ b/src/Command/Watch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -15,33 +17,20 @@ class Watch implements CommandInterface
     use ValidateTrait;
     use ToStringTrait;
 
-    /**
-     * @var string
-     */
-    protected $tube;
+    protected string $tube;
 
-    /**
-     * @param string $tube
-     */
-    public function __construct($tube)
+    public function __construct(string $tube)
     {
         $this->validateTubeName($tube);
         $this->tube = $tube;
     }
 
-    /**
-     * @return string
-     */
-    public function getCommand()
+    public function getCommand(): string
     {
         return sprintf('watch %s', $this->tube);
     }
 
-    /**
-     * @return integer
-     * @throws CommandException
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): int
     {
         $socket->write($this->getCommand());
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -150,7 +150,7 @@ class Connection implements ConnectionInterface
     public function ignore(string $tube)
     {
         if (isset($this->watching[$tube])) {
-            if (count($this->watching) == 1) {
+            if (count($this->watching) === 1) {
                 return false;
             }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -241,7 +241,7 @@ class Connection implements ConnectionInterface
      */
     public function peekReady()
     {
-        return $this->peekStatus(Command\Peek::READY);
+        return $this->peekStatus(Command\PeekStatus::READY);
     }
 
     /**
@@ -249,7 +249,7 @@ class Connection implements ConnectionInterface
      */
     public function peekDelayed()
     {
-        return $this->peekStatus(Command\Peek::DELAYED);
+        return $this->peekStatus(Command\PeekStatus::DELAYED);
     }
 
     /**
@@ -257,7 +257,7 @@ class Connection implements ConnectionInterface
      */
     public function peekBuried()
     {
-        return $this->peekStatus(Command\Peek::BURIED);
+        return $this->peekStatus(Command\PeekStatus::BURIED);
     }
 
     /**
@@ -267,7 +267,7 @@ class Connection implements ConnectionInterface
     protected function peekStatus($status)
     {
         try {
-            $jobData = (new Command\Peek($status))
+            $jobData = (new Command\PeekStatus($status))
                 ->process($this->getSocket());
             return $jobData;
         } catch (NotFoundException $e) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -12,7 +12,7 @@ use Phlib\Beanstalk\Exception\NotFoundException;
  */
 class Connection implements ConnectionInterface
 {
-    const DEFAULT_TUBE = 'default';
+    public const DEFAULT_TUBE = 'default';
 
     /**
      * @var string
@@ -32,13 +32,10 @@ class Connection implements ConnectionInterface
     /**
      * @var array
      */
-    protected $watching = [self::DEFAULT_TUBE => true];
+    protected $watching = [
+        self::DEFAULT_TUBE => true,
+    ];
 
-    /**
-     * Constructor
-     *
-     * @param SocketInterface $socket
-     */
     public function __construct(SocketInterface $socket)
     {
         $this->setSocket($socket);
@@ -54,7 +51,6 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param SocketInterface $socket
      * @return $this
      */
     public function setSocket(SocketInterface $socket)

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -14,25 +16,13 @@ class Connection implements ConnectionInterface
 {
     public const DEFAULT_TUBE = 'default';
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var SocketInterface
-     */
-    protected $socket;
+    protected SocketInterface $socket;
 
-    /**
-     * @var string
-     */
-    protected $using = self::DEFAULT_TUBE;
+    protected string $using = self::DEFAULT_TUBE;
 
-    /**
-     * @var array
-     */
-    protected $watching = [
+    protected array $watching = [
         self::DEFAULT_TUBE => true,
     ];
 
@@ -42,55 +32,34 @@ class Connection implements ConnectionInterface
         $this->name = $socket->getUniqueIdentifier();
     }
 
-    /**
-     * @return SocketInterface
-     */
-    public function getSocket()
+    public function getSocket(): SocketInterface
     {
         return $this->socket;
     }
 
-    /**
-     * @return $this
-     */
-    public function setSocket(SocketInterface $socket)
+    public function setSocket(SocketInterface $socket): self
     {
         $this->socket = $socket;
         return $this;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function disconnect()
+    public function disconnect(): bool
     {
         return $this->socket->disconnect();
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $value
-     * @return $this
-     */
-    public function setName($value)
+    public function setName(string $value): self
     {
         $this->name = $value;
         return $this;
     }
 
-    /**
-     * @param string $tube
-     * @return $this
-     * @throws Exception\CommandException
-     */
-    public function useTube($tube)
+    public function useTube(string $tube): self
     {
         (new Command\UseTube($tube))
             ->process($this->getSocket());
@@ -98,31 +67,21 @@ class Connection implements ConnectionInterface
         return $this;
     }
 
-    /**
-     * @param string   $data
-     * @param integer $priority
-     * @param integer $delay
-     * @param integer $ttr
-     * @return integer
-     * @throws Exception\CommandException
-     */
     public function put(
-        $data,
-        $priority = ConnectionInterface::DEFAULT_PRIORITY,
-        $delay = ConnectionInterface::DEFAULT_DELAY,
-        $ttr = ConnectionInterface::DEFAULT_TTR
-    ) {
+        string $data,
+        int $priority = ConnectionInterface::DEFAULT_PRIORITY,
+        int $delay = ConnectionInterface::DEFAULT_DELAY,
+        int $ttr = ConnectionInterface::DEFAULT_TTR
+    ): int {
         $data = (string)$data;
         return (new Command\Put($data, $priority, $delay, $ttr))
             ->process($this->getSocket());
     }
 
     /**
-     * @param integer $timeout
      * @return array|false
-     * @throws Exception\CommandException
      */
-    public function reserve($timeout = null)
+    public function reserve(?int $timeout = null)
     {
         $jobData = (new Command\Reserve($timeout))
             ->process($this->getSocket());
@@ -130,12 +89,9 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string|integer $id
-     * @return $this
-     * @throws Exception\NotFoundException
-     * @throws Exception\CommandException
+     * @param string|int $id
      */
-    public function delete($id)
+    public function delete($id): self
     {
         (new Command\Delete($id))
             ->process($this->getSocket());
@@ -143,31 +99,22 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string|integer $id
-     * @param integer        $priority
-     * @param integer        $delay
-     * @return $this
-     * @throws Exception\NotFoundException
-     * @throws Exception\CommandException
+     * @param string|int $id
      */
     public function release(
         $id,
-        $priority = ConnectionInterface::DEFAULT_PRIORITY,
-        $delay = ConnectionInterface::DEFAULT_DELAY
-    ) {
+        int $priority = ConnectionInterface::DEFAULT_PRIORITY,
+        int $delay = ConnectionInterface::DEFAULT_DELAY
+    ): self {
         (new Command\Release($id, $priority, $delay))
             ->process($this->getSocket());
         return $this;
     }
 
     /**
-     * @param string|integer $id
-     * @param integer        $priority
-     * @return $this
-     * @throws Exception\NotFoundException
-     * @throws Exception\CommandException
+     * @param string|int $id
      */
-    public function bury($id, $priority = ConnectionInterface::DEFAULT_PRIORITY)
+    public function bury($id, int $priority = ConnectionInterface::DEFAULT_PRIORITY): self
     {
         (new Command\Bury($id, $priority))
             ->process($this->getSocket());
@@ -175,24 +122,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string|integer $id
-     * @return $this
-     * @throws Exception\NotFoundException
-     * @throws Exception\CommandException
+     * @param string|int $id
      */
-    public function touch($id)
+    public function touch($id): self
     {
         (new Command\Touch($id))
             ->process($this->getSocket());
         return $this;
     }
 
-    /**
-     * @param string $tube
-     * @return $this
-     * @throws Exception\CommandException
-     */
-    public function watch($tube)
+    public function watch(string $tube): self
     {
         if (isset($this->watching[$tube])) {
             return $this;
@@ -206,11 +145,9 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string $tube
      * @return int|false
-     * @throws Exception\CommandException
      */
-    public function ignore($tube)
+    public function ignore(string $tube)
     {
         if (isset($this->watching[$tube])) {
             if (count($this->watching) == 1) {
@@ -226,10 +163,9 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string|integer $id
-     * @return array
+     * @param string|int $id
      */
-    public function peek($id)
+    public function peek($id): array
     {
         $jobData = (new Command\Peek($id))
             ->process($this->getSocket());
@@ -261,10 +197,9 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string $status
      * @return array|false
      */
-    protected function peekStatus($status)
+    protected function peekStatus(string $status)
     {
         try {
             $jobData = (new Command\PeekStatus($status))
@@ -276,7 +211,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @return array
+     * @return array|false
      */
     public function stats()
     {
@@ -285,56 +220,41 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * @param string|integer $id
-     * @return array
+     * @param string|int $id
      */
-    public function statsJob($id)
+    public function statsJob($id): array
     {
         return (new Command\StatsJob($id))
             ->process($this->getSocket());
     }
 
     /**
-     * @param string $tube
-     * @return array
+     * @return array|false
      */
-    public function statsTube($tube)
+    public function statsTube(string $tube)
     {
         return (new Command\StatsTube($tube))
             ->process($this->getSocket());
     }
 
-    /**
-     * @param integer $quantity
-     * @return integer
-     */
-    public function kick($quantity)
+    public function kick(int $quantity): int
     {
         return (new Command\Kick($quantity))
             ->process($this->getSocket());
     }
 
-    /**
-     * @return array
-     */
-    public function listTubes()
+    public function listTubes(): array
     {
         return (new Command\ListTubes())
             ->process($this->getSocket());
     }
 
-    /**
-     * @return array
-     */
-    public function listTubeUsed()
+    public function listTubeUsed(): string
     {
         return $this->using;
     }
 
-    /**
-     * @return array
-     */
-    public function listTubesWatched()
+    public function listTubesWatched(): array
     {
         return array_keys($this->watching);
     }

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Connection;
 
 /**
@@ -20,92 +22,63 @@ interface ConnectionInterface
 
     public const MAX_PRIORITY = 4294967295; // 2^32
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
+
+    public function disconnect(): bool;
+
+    public function useTube(string $tube): self;
 
     /**
-     * @return bool
-     */
-    public function disconnect();
-
-    /**
-     * @param string $tube
-     * @return $this
-     */
-    public function useTube($tube);
-
-    /**
-     * @param string  $data
-     * @param integer $priority
-     * @param integer $delay
-     * @param integer $ttr
-     * @return string|integer
+     * @return string|int
      */
     public function put(
-        $data,
-        $priority = self::DEFAULT_PRIORITY,
-        $delay = self::DEFAULT_DELAY,
-        $ttr = self::DEFAULT_TTR
+        string $data,
+        int $priority = self::DEFAULT_PRIORITY,
+        int $delay = self::DEFAULT_DELAY,
+        int $ttr = self::DEFAULT_TTR
     );
 
     /**
-     * @param integer $timeout
-     * @return array
+     * @return array|false
      */
-    public function reserve($timeout = null);
+    public function reserve(?int $timeout = null);
 
     /**
-     * @param string|integer $id
-     * @return $this
+     * @param string|int $id
      */
-    public function touch($id);
+    public function touch($id): self;
 
     /**
-     * @param integer $id
-     * @param integer $priority
-     * @param integer $delay
-     * @return $this
+     * @param string|int $id
      */
-    public function release($id, $priority = self::DEFAULT_PRIORITY, $delay = self::DEFAULT_DELAY);
+    public function release($id, int $priority = self::DEFAULT_PRIORITY, int $delay = self::DEFAULT_DELAY): self;
 
     /**
-     * @param integer $id
-     * @param integer $priority
-     * @return $this
+     * @param string|int $id
      */
-    public function bury($id, $priority = self::DEFAULT_PRIORITY);
+    public function bury($id, int $priority = self::DEFAULT_PRIORITY): self;
 
     /**
-     * @param integer $id
-     * @return $this
+     * @param string|int $id
      */
-    public function delete($id);
+    public function delete($id): self;
+
+    public function watch(string $tube): self;
 
     /**
-     * @param string $tube
-     * @return $this
-     */
-    public function watch($tube);
-
-    /**
-     * @param string $tube
      * @return int|false Number of tubes being watched or false
      */
-    public function ignore($tube);
+    public function ignore(string $tube);
 
     /**
-     * @param integer $id
-     * @return array
+     * @param string|int $id
      */
-    public function peek($id);
+    public function peek($id): array;
 
     /**
-     * @param integer $id
-     * @return array
+     * @param string|int $id
      */
-    public function statsJob($id);
+    public function statsJob($id): array;
 
     /**
      * @return array|false
@@ -122,35 +95,21 @@ interface ConnectionInterface
      */
     public function peekBuried();
 
-    /**
-     * @param integer $quantity
-     * @return integer
-     */
-    public function kick($quantity);
+    public function kick(int $quantity): int;
 
     /**
-     * @param string $tube
-     * @return array
+     * @return array|false
      */
-    public function statsTube($tube);
+    public function statsTube(string $tube);
 
     /**
-     * @return array
+     * @return array|false
      */
     public function stats();
 
-    /**
-     * @return array
-     */
-    public function listTubes();
+    public function listTubes(): array;
 
-    /**
-     * @return string
-     */
-    public function listTubeUsed();
+    public function listTubeUsed(): string;
 
-    /**
-     * @return array
-     */
-    public function listTubesWatched();
+    public function listTubesWatched(): array;
 }

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -8,13 +8,17 @@ namespace Phlib\Beanstalk\Connection;
  */
 interface ConnectionInterface
 {
-    const DEFAULT_PRIORITY = 1024;
-    const DEFAULT_DELAY = 0;
-    const DEFAULT_TTR = 60;
+    public const DEFAULT_PRIORITY = 1024;
 
-    const MAX_JOB_LENGTH  = 65536;      // 2^16
-    const MAX_TUBE_LENGTH = 200;
-    const MAX_PRIORITY    = 4294967295; // 2^32
+    public const DEFAULT_DELAY = 0;
+
+    public const DEFAULT_TTR = 60;
+
+    public const MAX_JOB_LENGTH = 65536; // 2^16
+
+    public const MAX_TUBE_LENGTH = 200;
+
+    public const MAX_PRIORITY = 4294967295; // 2^32
 
     /**
      * @return string

--- a/src/Connection/Socket.php
+++ b/src/Connection/Socket.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Connection;
 
 use Phlib\Beanstalk\Exception;
@@ -16,33 +18,18 @@ class Socket implements SocketInterface
 
     private const READ_LENGTH = 4096;
 
-    /**
-     * @var string
-     */
-    protected $host;
+    protected string $host;
 
-    /**
-     * @var integer
-     */
-    protected $port;
+    protected int $port;
 
-    /**
-     * @var array
-     */
-    protected $options;
+    protected array $options;
 
     /**
      * @var resource
      */
     protected $connection;
 
-    /**
-     * Constructor
-     *
-     * @param string  $host
-     * @param integer $port
-     */
-    public function __construct($host, $port = self::DEFAULT_PORT, array $options = [])
+    public function __construct(string $host, int $port = self::DEFAULT_PORT, array $options = [])
     {
         $this->host = $host;
         $this->port = $port;
@@ -51,29 +38,17 @@ class Socket implements SocketInterface
         ];
     }
 
-    /**
-     * Destructor
-     */
     public function __destruct()
     {
         $this->disconnect();
     }
 
-    /**
-     * @return string
-     */
-    public function getUniqueIdentifier()
+    public function getUniqueIdentifier(): string
     {
         return "{$this->host}:{$this->port}";
     }
 
-    /**
-     * Connect the socket to the beanstalk server.
-     *
-     * @return $this
-     * @throws Exception\SocketException
-     */
-    public function connect()
+    public function connect(): self
     {
         if (!$this->connection) {
             $errNum = $errStr = null;
@@ -97,14 +72,7 @@ class Socket implements SocketInterface
         return $this;
     }
 
-    /**
-     * Write to the socket.
-     *
-     * @param  string $data
-     * @return $this
-     * @throws Exception\SocketException
-     */
-    public function write($data)
+    public function write(string $data): self
     {
         $this->connect();
 
@@ -120,12 +88,7 @@ class Socket implements SocketInterface
         return $this;
     }
 
-    /**
-     * @param integer|null $length
-     * @return string
-     * @throws Exception\SocketException
-     */
-    public function read($length = null)
+    public function read(int $length = null): string
     {
         $this->connect();
 
@@ -151,10 +114,7 @@ class Socket implements SocketInterface
         return $data;
     }
 
-    /**
-     * @return $this
-     */
-    public function disconnect()
+    public function disconnect(): bool
     {
         if (is_resource($this->connection)) {
             fclose($this->connection);

--- a/src/Connection/Socket.php
+++ b/src/Connection/Socket.php
@@ -3,7 +3,6 @@
 namespace Phlib\Beanstalk\Connection;
 
 use Phlib\Beanstalk\Exception;
-use Phlib\Beanstalk\Connection\SocketInterface;
 
 /**
  * Class Socket
@@ -11,9 +10,11 @@ use Phlib\Beanstalk\Connection\SocketInterface;
  */
 class Socket implements SocketInterface
 {
-    const DEFAULT_PORT = 11300;
-    const EOL          = "\r\n";
-    const READ_LENGTH  = 4096;
+    public const DEFAULT_PORT = 11300;
+
+    public const EOL = "\r\n";
+
+    private const READ_LENGTH = 4096;
 
     /**
      * @var string
@@ -40,13 +41,14 @@ class Socket implements SocketInterface
      *
      * @param string  $host
      * @param integer $port
-     * @param array   $options
      */
     public function __construct($host, $port = self::DEFAULT_PORT, array $options = [])
     {
-        $this->host    = $host;
-        $this->port    = $port;
-        $this->options = $options + ['timeout' => 60];
+        $this->host = $host;
+        $this->port = $port;
+        $this->options = $options + [
+            'timeout' => 60,
+        ];
     }
 
     /**
@@ -108,7 +110,7 @@ class Socket implements SocketInterface
 
         $data .= self::EOL;
         $bytesWritten = strlen($data);
-        $bytesSent    = fwrite($this->connection, $data, $bytesWritten);
+        $bytesSent = fwrite($this->connection, $data, $bytesWritten);
 
         if ($bytesSent !== $bytesWritten) {
             $this->disconnect();

--- a/src/Connection/SocketInterface.php
+++ b/src/Connection/SocketInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Connection;
 
 /**
@@ -8,25 +10,11 @@ namespace Phlib\Beanstalk\Connection;
  */
 interface SocketInterface
 {
-    /**
-     * @return string
-     */
-    public function getUniqueIdentifier();
+    public function getUniqueIdentifier(): string;
 
-    /**
-     * @param string $data
-     * @return $this
-     */
-    public function write($data);
+    public function write(string $data): self;
 
-    /**
-     * @param integer|null $length
-     * @return string
-     */
-    public function read($length = null);
+    public function read(int $length = null): string;
 
-    /**
-     * @return bool
-     */
-    public function disconnect();
+    public function disconnect(): bool;
 }

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -3,9 +3,9 @@
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
-use Symfony\Component\Console\Command\Command;
 use Phlib\Beanstalk\Factory;
 use Phlib\Beanstalk\StatsService;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Class AbstractCommand

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -13,19 +15,13 @@ use Symfony\Component\Console\Command\Command;
  */
 abstract class AbstractCommand extends Command
 {
-    /**
-     * @var ConnectionInterface
-     */
-    protected $beanstalk;
+    protected ConnectionInterface $beanstalk;
 
     private StatsService $statsService;
 
-    /**
-     * @return ConnectionInterface
-     */
-    public function getBeanstalk()
+    public function getBeanstalk(): ConnectionInterface
     {
-        if (!$this->beanstalk) {
+        if (!isset($this->beanstalk)) {
             $config = $this->getHelper('configuration')->fetch();
             $this->beanstalk = Factory::createFromArray($config);
         }

--- a/src/Console/DisplayJobTrait.php
+++ b/src/Console/DisplayJobTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -7,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait DisplayJobTrait
 {
-    protected function displayJob(array $job, OutputInterface $output)
+    protected function displayJob(array $job, OutputInterface $output): void
     {
         /** @var FormatterHelper $formatter */
         $formatter = $this->getHelper('formatter');

--- a/src/Console/DisplayJobTrait.php
+++ b/src/Console/DisplayJobTrait.php
@@ -7,15 +7,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait DisplayJobTrait
 {
-    /**
-     * @param array $job
-     * @param OutputInterface $output
-     */
     protected function displayJob(array $job, OutputInterface $output)
     {
         /** @var FormatterHelper $formatter */
         $formatter = $this->getHelper('formatter');
-        $section   = $formatter->formatSection("Job ID: {$job['id']}", var_export($job['body'], true));
+        $section = $formatter->formatSection("Job ID: {$job['id']}", var_export($job['body'], true));
         $output->writeln($section);
     }
 }

--- a/src/Console/JobDeleteCommand.php
+++ b/src/Console/JobDeleteCommand.php
@@ -2,10 +2,8 @@
 
 namespace Phlib\Beanstalk\Console;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class JobDeleteCommand extends AbstractCommand
@@ -21,7 +19,7 @@ class JobDeleteCommand extends AbstractCommand
     {
         $jobId = $input->getArgument('job-id');
         $this->getBeanstalk()->delete($jobId);
-        $output->writeln("Job '$jobId' successfully deleted.");
+        $output->writeln("Job '{$jobId}' successfully deleted.");
 
         return 0;
     }

--- a/src/Console/JobDeleteCommand.php
+++ b/src/Console/JobDeleteCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
@@ -8,14 +10,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class JobDeleteCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('job:delete')
             ->setDescription('Delete specific job.')
             ->addArgument('job-id', InputArgument::REQUIRED, 'The ID of the job.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jobId = $input->getArgument('job-id');
         $this->getBeanstalk()->delete($jobId);

--- a/src/Console/JobPeekCommand.php
+++ b/src/Console/JobPeekCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
@@ -10,14 +12,14 @@ class JobPeekCommand extends AbstractCommand
 {
     use DisplayJobTrait;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('job:peek')
             ->setDescription('View information about a specific job.')
             ->addArgument('job-id', InputArgument::REQUIRED, 'The ID of the job.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jobId = $input->getArgument('job-id');
         $job = $this->getBeanstalk()->peek($jobId);

--- a/src/Console/JobPeekCommand.php
+++ b/src/Console/JobPeekCommand.php
@@ -2,10 +2,8 @@
 
 namespace Phlib\Beanstalk\Console;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class JobPeekCommand extends AbstractCommand

--- a/src/Console/JobStatsCommand.php
+++ b/src/Console/JobStatsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Symfony\Component\Console\Helper\Table;
@@ -9,14 +11,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class JobStatsCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('job:stats')
             ->setDescription('List statistics related to a specific job.')
             ->addArgument('job-id', InputArgument::REQUIRED, 'The ID of the job.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jobId = $input->getArgument('job-id');
         $stats = $this->getBeanstalk()->statsJob($jobId);

--- a/src/Console/JobStatsCommand.php
+++ b/src/Console/JobStatsCommand.php
@@ -2,11 +2,9 @@
 
 namespace Phlib\Beanstalk\Console;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class JobStatsCommand extends AbstractCommand
@@ -22,7 +20,7 @@ class JobStatsCommand extends AbstractCommand
     {
         $jobId = $input->getArgument('job-id');
         $stats = $this->getBeanstalk()->statsJob($jobId);
-        $output->writeln("<info>[Job ID: $jobId]</info>");
+        $output->writeln("<info>[Job ID: {$jobId}]</info>");
 
         $table = new Table($output);
         $table->setStyle('compact');
@@ -36,8 +34,8 @@ class JobStatsCommand extends AbstractCommand
         $table->render();
 
         $created = time();
-        $table   = new Table($output);
-        $stats   = array_diff_key($stats, array_flip(['id', 'tube', 'state']));
+        $table = new Table($output);
+        $stats = array_diff_key($stats, array_flip(['id', 'tube', 'state']));
         $table->setHeaders(['Stat', 'Value']);
         foreach ($stats as $stat => $value) {
             if ($stat == 'age') {

--- a/src/Console/JobStatsCommand.php
+++ b/src/Console/JobStatsCommand.php
@@ -28,7 +28,7 @@ class JobStatsCommand extends AbstractCommand
         $table->setStyle('compact');
         $details = array_intersect_key($stats, array_flip(['tube', 'state']));
         foreach ($details as $detail => $value) {
-            if ($detail == 'state' && $value == 'buried') {
+            if ($detail === 'state' && $value === 'buried') {
                 $value = "<error>{$value}</error>";
             }
             $table->addRow([$detail, $value]);
@@ -40,11 +40,11 @@ class JobStatsCommand extends AbstractCommand
         $stats = array_diff_key($stats, array_flip(['id', 'tube', 'state']));
         $table->setHeaders(['Stat', 'Value']);
         foreach ($stats as $stat => $value) {
-            if ($stat == 'age') {
+            if ($stat === 'age') {
                 $created = time() - (int)$value;
                 $dt = date('Y-m-d H:i:s', $created);
                 $table->addRow(['created', $dt]);
-            } elseif ($stat == 'delay') {
+            } elseif ($stat === 'delay') {
                 $dt = date('Y-m-d H:i:s', $created + (int)$value);
                 $table->addRow(['scheduled', $dt]);
             }

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -2,13 +2,13 @@
 
 namespace Phlib\Beanstalk\Console;
 
-use Phlib\Beanstalk\StatsService;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
+use Phlib\Beanstalk\StatsService;
 use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\Table;
 
 class ServerStatsCommand extends AbstractCommand
 {
@@ -21,7 +21,7 @@ class ServerStatsCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stat    = $input->getOption('stat');
+        $stat = $input->getOption('stat');
         $service = $this->getStatsService();
 
         $this->outputDetectedConfig($output);
@@ -59,7 +59,7 @@ class ServerStatsCommand extends AbstractCommand
                 "Host: {$info['hostname']} (pid {$info['pid']})",
                 "Beanstalk Version: {$info['version']}",
                 "Resources: uptime/{$info['uptime']}, connections/{$info['total-connections']}",
-                "Jobs: total/{$info['total-jobs']}, timeouts/{$info['job-timeouts']}"
+                "Jobs: total/{$info['total-jobs']}, timeouts/{$info['job-timeouts']}",
             ],
             'info',
             true
@@ -69,13 +69,9 @@ class ServerStatsCommand extends AbstractCommand
         $output->writeln($block);
     }
 
-    /**
-     * @param StatsService $stats
-     * @param OutputInterface $output
-     */
     protected function outputStats(StatsService $stats, OutputInterface $output)
     {
-        $binlog  = $stats->getServerStats(StatsService::SERVER_BINLOG);
+        $binlog = $stats->getServerStats(StatsService::SERVER_BINLOG);
         $command = $stats->getServerStats(StatsService::SERVER_COMMAND);
         $current = $stats->getServerStats(StatsService::SERVER_CURRENT);
 
@@ -83,15 +79,15 @@ class ServerStatsCommand extends AbstractCommand
         $table->setStyle('borderless');
         $table->setHeaders(['Current', 'Stat', 'Command', 'Stat', 'Binlog', 'Stat']);
 
-        $binlogKeys    = array_keys($binlog);
-        $binlogValues  = array_values($binlog);
-        $commandKeys   = array_keys($command);
+        $binlogKeys = array_keys($binlog);
+        $binlogValues = array_values($binlog);
+        $commandKeys = array_keys($command);
         $commandValues = array_values($command);
-        $currentKeys   = array_keys($current);
+        $currentKeys = array_keys($current);
         $currentValues = array_values($current);
 
         $maxRows = max(count($binlog), count($command), count($current));
-        for ($i=0; $i < $maxRows; $i++) {
+        for ($i = 0; $i < $maxRows; $i++) {
             $row = [
                 $currentKeys[$i] ?? '',
                 $currentValues[$i] ?? '',
@@ -108,16 +104,14 @@ class ServerStatsCommand extends AbstractCommand
     }
 
     /**
-     * @param StatsService $service
      * @param string $stat
-     * @param OutputInterface $output
      * @throws InvalidArgumentException
      */
     protected function outputStat(StatsService $service, $stat, OutputInterface $output)
     {
         $stats = $service->getServerStats(StatsService::SERVER_ALL) + $service->getServerInfo();
         if (!isset($stats[$stat])) {
-            throw new InvalidArgumentException("Specified statistic '$stat' is not valid.");
+            throw new InvalidArgumentException("Specified statistic '{$stat}' is not valid.");
         }
 
         $output->writeln($stats[$stat]);

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -27,7 +27,7 @@ class ServerStatsCommand extends AbstractCommand
         $service = $this->getStatsService();
 
         $this->outputDetectedConfig($output);
-        if ($stat == '') {
+        if (empty($stat)) {
             $this->outputInfo($service, $output);
             $this->outputStats($service, $output);
         } else {
@@ -43,7 +43,7 @@ class ServerStatsCommand extends AbstractCommand
             return;
         }
         $configPath = $this->getHelper('configuration')->getConfigPath();
-        if ($configPath == '[default]') {
+        if ($configPath === '[default]') {
             $configPath = '[default fallback localhost]';
         }
 

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -12,14 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ServerStatsCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('server:stats')
             ->setDescription('Get a list of details about the beanstalk server(s).')
             ->addOption('stat', 's', InputOption::VALUE_REQUIRED, 'Output a specific statistic.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $stat = $input->getOption('stat');
         $service = $this->getStatsService();
@@ -35,7 +37,7 @@ class ServerStatsCommand extends AbstractCommand
         return 0;
     }
 
-    protected function outputDetectedConfig(OutputInterface $output)
+    protected function outputDetectedConfig(OutputInterface $output): void
     {
         if (!$output->isVerbose()) {
             return;
@@ -48,7 +50,7 @@ class ServerStatsCommand extends AbstractCommand
         $output->writeln('Configuration: ' . $configPath);
     }
 
-    protected function outputInfo(StatsService $stats, OutputInterface $output)
+    protected function outputInfo(StatsService $stats, OutputInterface $output): void
     {
         $info = $stats->getServerInfo();
 
@@ -69,7 +71,7 @@ class ServerStatsCommand extends AbstractCommand
         $output->writeln($block);
     }
 
-    protected function outputStats(StatsService $stats, OutputInterface $output)
+    protected function outputStats(StatsService $stats, OutputInterface $output): void
     {
         $binlog = $stats->getServerStats(StatsService::SERVER_BINLOG);
         $command = $stats->getServerStats(StatsService::SERVER_COMMAND);
@@ -103,11 +105,7 @@ class ServerStatsCommand extends AbstractCommand
         $table->render();
     }
 
-    /**
-     * @param string $stat
-     * @throws InvalidArgumentException
-     */
-    protected function outputStat(StatsService $service, $stat, OutputInterface $output)
+    protected function outputStat(StatsService $service, string $stat, OutputInterface $output): void
     {
         $stats = $service->getServerStats(StatsService::SERVER_ALL) + $service->getServerInfo();
         if (!isset($stats[$stat])) {

--- a/src/Console/ServerTubesCommand.php
+++ b/src/Console/ServerTubesCommand.php
@@ -19,7 +19,7 @@ class ServerTubesCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $watch    = $input->getOption('watch');
+        $watch = $input->getOption('watch');
         $buffered = new BufferedOutput($output->getVerbosity(), $output->isDecorated());
         $service = $this->getStatsService();
         do {
@@ -45,7 +45,6 @@ class ServerTubesCommand extends AbstractCommand
             $output->write($clearScreen . $buffered->fetch());
 
             $watch && sleep(1);
-
         } while ($watch);
 
         return 0;

--- a/src/Console/ServerTubesCommand.php
+++ b/src/Console/ServerTubesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\StatsService;
@@ -10,14 +12,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ServerTubesCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('server:tubes')
             ->setDescription('List all tubes known to the server(s).')
             ->addOption('watch', null, null, 'Watch server values by refreshing stats every second');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $watch = $input->getOption('watch');
         $buffered = new BufferedOutput($output->getVerbosity(), $output->isDecorated());

--- a/src/Console/TubeKickCommand.php
+++ b/src/Console/TubeKickCommand.php
@@ -2,10 +2,8 @@
 
 namespace Phlib\Beanstalk\Console;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TubeKickCommand extends AbstractCommand
@@ -23,7 +21,7 @@ class TubeKickCommand extends AbstractCommand
         $quantity = $this->getBeanstalk()
             ->useTube($input->getArgument('tube'))
             ->kick($input->getArgument('quantity'));
-        $output->writeln("Successfully kicked $quantity jobs.");
+        $output->writeln("Successfully kicked {$quantity} jobs.");
 
         return 0;
     }

--- a/src/Console/TubeKickCommand.php
+++ b/src/Console/TubeKickCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
@@ -8,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TubeKickCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('tube:kick')
             ->setDescription('Kick a number of delayed or buried jobs in the tube.')
@@ -16,7 +18,7 @@ class TubeKickCommand extends AbstractCommand
             ->addArgument('quantity', InputArgument::REQUIRED, 'The number of jobs to kick.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $quantity = $this->getBeanstalk()
             ->useTube($input->getArgument('tube'))

--- a/src/Console/TubePeekCommand.php
+++ b/src/Console/TubePeekCommand.php
@@ -24,7 +24,7 @@ class TubePeekCommand extends AbstractCommand
     {
         $status = $input->getOption('status');
         if (!in_array($status, ['ready', 'delayed', 'buried'], true)) {
-            throw new InvalidArgumentException("Specified status '$status' is not valid.");
+            throw new InvalidArgumentException("Specified status '{$status}' is not valid.");
         }
 
         $this->getBeanstalk()
@@ -33,7 +33,7 @@ class TubePeekCommand extends AbstractCommand
         $job = call_user_func([$this->getBeanstalk(), $method]);
 
         if ($job === false) {
-            $output->writeln("No jobs found in '$status' status.");
+            $output->writeln("No jobs found in '{$status}' status.");
         } else {
             $this->displayJob($job, $output);
         }

--- a/src/Console/TubePeekCommand.php
+++ b/src/Console/TubePeekCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -12,7 +14,7 @@ class TubePeekCommand extends AbstractCommand
 {
     use DisplayJobTrait;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('tube:peek')
             ->setDescription('Look at a job in the job based on status.')
@@ -20,7 +22,7 @@ class TubePeekCommand extends AbstractCommand
             ->addOption('status', 's', InputOption::VALUE_OPTIONAL, 'The tube status. Value can be ready, delayed or buried.', 'buried');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $status = $input->getOption('status');
 

--- a/src/Console/TubeStatsCommand.php
+++ b/src/Console/TubeStatsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -11,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TubeStatsCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('tube:stats')
             ->setDescription('Display stats for the specified tube.')
@@ -19,7 +21,7 @@ class TubeStatsCommand extends AbstractCommand
             ->addOption('stat', 's', InputOption::VALUE_REQUIRED, 'Output a specific statistic.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tube = $input->getArgument('tube');
         $stat = $input->getOption('stat');
@@ -41,7 +43,7 @@ class TubeStatsCommand extends AbstractCommand
         return 0;
     }
 
-    protected function displayTable(array $stats, OutputInterface $output)
+    protected function displayTable(array $stats, OutputInterface $output): void
     {
         $table = new Table($output);
         $table->setHeaders(['Statistic', 'Total']);
@@ -56,10 +58,7 @@ class TubeStatsCommand extends AbstractCommand
         $table->render();
     }
 
-    /**
-     * @param string $stat
-     */
-    protected function displayStat(array $stats, $stat, OutputInterface $output)
+    protected function displayStat(array $stats, string $stat, OutputInterface $output): void
     {
         if (!isset($stats[$stat])) {
             throw new InvalidArgumentException("Specified statistic '{$stat}' is not valid.");

--- a/src/Console/TubeStatsCommand.php
+++ b/src/Console/TubeStatsCommand.php
@@ -3,7 +3,6 @@
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Phlib\Beanstalk\StatsService;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,7 +28,7 @@ class TubeStatsCommand extends AbstractCommand
         $stats = $service->getTubeStats($tube);
 
         if (empty($stats)) {
-            $output->writeln("No statistics found for tube '$tube'.");
+            $output->writeln("No statistics found for tube '{$tube}'.");
             return 0;
         }
 
@@ -42,17 +41,13 @@ class TubeStatsCommand extends AbstractCommand
         return 0;
     }
 
-    /**
-     * @param array $stats
-     * @param OutputInterface $output
-     */
     protected function displayTable(array $stats, OutputInterface $output)
     {
         $table = new Table($output);
         $table->setHeaders(['Statistic', 'Total']);
         foreach ($stats as $stat => $total) {
             if ($stat == 'current-jobs-buried' && $total > 0) {
-                $stat  = "<error>$stat</error>";
+                $stat = "<error>{$stat}</error>";
                 $total = "<error>{$total}</error>";
             }
             $table->addRow([$stat, $total]);
@@ -62,14 +57,12 @@ class TubeStatsCommand extends AbstractCommand
     }
 
     /**
-     * @param array $stats
      * @param string $stat
-     * @param OutputInterface $output
      */
     protected function displayStat(array $stats, $stat, OutputInterface $output)
     {
         if (!isset($stats[$stat])) {
-            throw new InvalidArgumentException("Specified statistic '$stat' is not valid.");
+            throw new InvalidArgumentException("Specified statistic '{$stat}' is not valid.");
         }
 
         $output->writeln($stats[$stat]);

--- a/src/Console/TubeStatsCommand.php
+++ b/src/Console/TubeStatsCommand.php
@@ -34,7 +34,7 @@ class TubeStatsCommand extends AbstractCommand
             return 0;
         }
 
-        if ($stat == '') {
+        if (empty($stat)) {
             $this->displayTable($stats, $output);
         } else {
             $this->displayStat($stats, $stat, $output);
@@ -48,7 +48,7 @@ class TubeStatsCommand extends AbstractCommand
         $table = new Table($output);
         $table->setHeaders(['Statistic', 'Total']);
         foreach ($stats as $stat => $total) {
-            if ($stat == 'current-jobs-buried' && $total > 0) {
+            if ($stat === 'current-jobs-buried' && $total > 0) {
                 $stat = "<error>{$stat}</error>";
                 $total = "<error>{$total}</error>";
             }

--- a/src/Exception/CommandException.php
+++ b/src/Exception/CommandException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Exception;
 
 class CommandException extends RuntimeException

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Exception;
 
 interface Exception

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements Exception

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Exception;
 
 class NotFoundException extends \Exception implements Exception

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Exception;
 
 class RuntimeException extends \RuntimeException implements Exception

--- a/src/Exception/SocketException.php
+++ b/src/Exception/SocketException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Exception;
 
 class SocketException extends RuntimeException

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,8 +3,8 @@
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
-use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use Phlib\Beanstalk\Connection\Socket;
+use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use Phlib\Beanstalk\Pool\Collection;
 use Phlib\Beanstalk\Pool\RoundRobinStrategy;
 use Phlib\Beanstalk\Pool\SelectionStrategyInterface;
@@ -18,7 +18,6 @@ class Factory
     /**
      * @param string $host
      * @param integer $port
-     * @param array $options
      * @return Connection
      */
     public static function create($host, $port = Socket::DEFAULT_PORT, array $options = [])
@@ -27,24 +26,25 @@ class Factory
     }
 
     /**
-     * @param array $config
      * @return ConnectionInterface
      */
     public static function createFromArray(array $config)
     {
         if (array_key_exists('host', $config)) {
-            $config = ['server' => $config];
+            $config = [
+                'server' => $config,
+            ];
         }
 
         if (array_key_exists('server', $config)) {
-            $server     = static::normalizeArgs($config['server']);
+            $server = static::normalizeArgs($config['server']);
             $connection = static::create($server['host'], $server['port'], $server['options']);
         } elseif (array_key_exists('servers', $config)) {
             if (!isset($config['strategyClass'])) {
                 $config['strategyClass'] = RoundRobinStrategy::class;
             }
-            $servers    = static::createConnections($config['servers']);
-            $strategy   = static::createStrategy($config['strategyClass']);
+            $servers = static::createConnections($config['servers']);
+            $strategy = static::createStrategy($config['strategyClass']);
             $connection = new Pool(new Collection($servers, $strategy));
         } else {
             throw new InvalidArgumentException('Missing required server(s) configuration');
@@ -54,14 +54,13 @@ class Factory
     }
 
     /**
-     * @param array $servers
      * @return Connection[]
      */
     public static function createConnections(array $servers)
     {
         $connections = [];
         foreach ($servers as $server) {
-            if (array_key_exists('enabled', $server) && $server['enabled'] == false) {
+            if (array_key_exists('enabled', $server) && $server['enabled'] === false) {
                 continue;
             }
             $server = static::normalizeArgs($server);
@@ -80,11 +79,10 @@ class Factory
         if (!class_exists($class)) {
             throw new InvalidArgumentException("Specified Pool strategy class '{$class}' does not exist.");
         }
-        return new $class;
+        return new $class();
     }
 
     /**
-     * @param array $serverArgs
      * @return array
      */
     protected static function normalizeArgs(array $serverArgs)
@@ -92,7 +90,7 @@ class Factory
         return $serverArgs + [
             'host' => null,
             'port' => Socket::DEFAULT_PORT,
-            'options' => []
+            'options' => [],
         ];
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -15,20 +17,12 @@ use Phlib\Beanstalk\Pool\SelectionStrategyInterface;
  */
 class Factory
 {
-    /**
-     * @param string $host
-     * @param integer $port
-     * @return Connection
-     */
-    public static function create($host, $port = Socket::DEFAULT_PORT, array $options = [])
+    public static function create(string $host, int $port = Socket::DEFAULT_PORT, array $options = []): Connection
     {
         return new Connection(new Socket($host, $port, $options));
     }
 
-    /**
-     * @return ConnectionInterface
-     */
-    public static function createFromArray(array $config)
+    public static function createFromArray(array $config): ConnectionInterface
     {
         if (array_key_exists('host', $config)) {
             $config = [
@@ -56,7 +50,7 @@ class Factory
     /**
      * @return Connection[]
      */
-    public static function createConnections(array $servers)
+    public static function createConnections(array $servers): array
     {
         $connections = [];
         foreach ($servers as $server) {
@@ -70,11 +64,7 @@ class Factory
         return $connections;
     }
 
-    /**
-     * @param string $class
-     * @return SelectionStrategyInterface
-     */
-    public static function createStrategy($class)
+    public static function createStrategy(string $class): SelectionStrategyInterface
     {
         if (!class_exists($class)) {
             throw new InvalidArgumentException("Specified Pool strategy class '{$class}' does not exist.");
@@ -82,10 +72,7 @@ class Factory
         return new $class();
     }
 
-    /**
-     * @return array
-     */
-    protected static function normalizeArgs(array $serverArgs)
+    protected static function normalizeArgs(array $serverArgs): array
     {
         return $serverArgs + [
             'host' => null,

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -148,13 +148,12 @@ class Pool implements ConnectionInterface
      */
     public function ignore(string $tube)
     {
-        $index = array_search($tube, $this->watching);
-        if ($index !== false) {
+        if (isset($this->watching[$tube])) {
             if (count($this->watching) === 1) {
                 return false;
             }
             $this->collection->sendToAll('ignore', [$tube]);
-            unset($this->watching[$index]);
+            unset($this->watching[$tube]);
         }
         return count($this->watching);
     }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -216,9 +216,9 @@ class Pool implements ConnectionInterface
         $kicked = 0;
         $onSuccess = function (array $result) use ($quantity, &$kicked): bool {
             $stats = $result['response'];
-            $buriedJobs = $stats['current-jobs-buried'] ?? 0;
+            $buriedJobs = (int)$stats['current-jobs-buried'] ?? 0;
 
-            if ($buriedJobs == 0) {
+            if ($buriedJobs === 0) {
                 return true;
             }
 
@@ -299,11 +299,11 @@ class Pool implements ConnectionInterface
                 continue;
             }
 
-            if (in_array($name, $list)) {
-                if ($cumulative[$name] != $value) {
+            if (in_array($name, $list, true)) {
+                if ($cumulative[$name] !== $value) {
                     $cumulative[$name] .= ',' . $value;
                 }
-            } elseif (in_array($name, $maximum)) {
+            } elseif (in_array($name, $maximum, true)) {
                 if ($value > $cumulative[$name]) {
                     $cumulative[$name] = $value;
                 }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -3,9 +3,9 @@
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
+use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use Phlib\Beanstalk\Exception\RuntimeException;
 use Phlib\Beanstalk\Pool\CollectionInterface;
-use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 class Pool implements ConnectionInterface
 {
@@ -22,11 +22,10 @@ class Pool implements ConnectionInterface
     /**
      * @var array
      */
-    protected $watching = [Connection::DEFAULT_TUBE => true];
+    protected $watching = [
+        Connection::DEFAULT_TUBE => true,
+    ];
 
-    /**
-     * @param CollectionInterface $collection
-     */
     public function __construct(CollectionInterface $collection)
     {
         $this->collection = $collection;
@@ -191,7 +190,7 @@ class Pool implements ConnectionInterface
     {
         $index = array_search($tube, $this->watching);
         if ($index !== false) {
-            if (count($this->watching) == 1) {
+            if (count($this->watching) === 1) {
                 return false;
             }
             $this->collection->sendToAll('ignore', [$tube]);
@@ -207,8 +206,8 @@ class Pool implements ConnectionInterface
     public function peek($id)
     {
         [$key, $jobId] = $this->splitId($id);
-        $result    = $this->collection->sendToExact($key, 'peek', [$jobId]);
-        $job       = $result['response'];
+        $result = $this->collection->sendToExact($key, 'peek', [$jobId]);
+        $job = $result['response'];
         $job['id'] = $id;
         return $job;
     }
@@ -260,7 +259,7 @@ class Pool implements ConnectionInterface
      */
     public function kick($quantity)
     {
-        $kicked    = 0;
+        $kicked = 0;
         $onSuccess = function ($result) use ($quantity, &$kicked) {
             $stats = $result['response'];
             $buriedJobs = $stats['current-jobs-buried'] ?? 0;
@@ -269,7 +268,7 @@ class Pool implements ConnectionInterface
                 return true;
             }
 
-            $kick   = min($buriedJobs, $quantity - $kicked);
+            $kick = min($buriedJobs, $quantity - $kicked);
             $kicked += (int)$result['connection']->kick($kick);
 
             if ($kicked >= $quantity) {
@@ -286,7 +285,7 @@ class Pool implements ConnectionInterface
      */
     public function stats()
     {
-        $stats     = [];
+        $stats = [];
         $onSuccess = function ($result) use (&$stats) {
             if (!is_array($result['response'])) {
                 return;
@@ -308,8 +307,8 @@ class Pool implements ConnectionInterface
     public function statsJob($id)
     {
         [$key, $jobId] = $this->splitId($id);
-        $result    = $this->collection->sendToExact($key, 'statsJob', [$jobId]);
-        $job       = $result['response'];
+        $result = $this->collection->sendToExact($key, 'statsJob', [$jobId]);
+        $job = $result['response'];
         $job['id'] = $id;
         return $job;
     }
@@ -320,7 +319,7 @@ class Pool implements ConnectionInterface
      */
     public function statsTube($tube)
     {
-        $stats     = [];
+        $stats = [];
         $onSuccess = function ($result) use (&$stats) {
             if (!is_array($result['response'])) {
                 return;
@@ -336,13 +335,11 @@ class Pool implements ConnectionInterface
     }
 
     /**
-     * @param array $cumulative
-     * @param array $stats
      * @return array
      */
     protected function statsCombine(array $cumulative, array $stats)
     {
-        $list    = ['pid', 'version', 'hostname', 'name', 'uptime', 'binlog-current-index'];
+        $list = ['pid', 'version', 'hostname', 'name', 'uptime', 'binlog-current-index'];
         $maximum = ['timeouts', 'binlog-max-size', 'binlog-oldest-index'];
         foreach ($stats as $name => $value) {
             if (!array_key_exists($name, $cumulative)) {
@@ -370,7 +367,7 @@ class Pool implements ConnectionInterface
      */
     public function listTubes()
     {
-        $tubes     = [];
+        $tubes = [];
         $onSuccess = function ($result) use (&$tubes) {
             if (!is_array($result['response'])) {
                 return;
@@ -398,7 +395,6 @@ class Pool implements ConnectionInterface
     }
 
     /**
-     * @param ConnectionInterface $connection
      * @param integer $id
      * @return string
      */
@@ -422,8 +418,8 @@ class Pool implements ConnectionInterface
         }
 
         $position = strrpos($id, '.');
-        $key      = substr($id, 0, $position);
-        $jobId    = substr($id, $position + 1);
+        $key = substr($id, 0, $position);
+        $jobId = substr($id, $position + 1);
 
         return [$key, $jobId];
     }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -260,7 +260,7 @@ class Pool implements ConnectionInterface
     public function kick($quantity)
     {
         $kicked = 0;
-        $onSuccess = function ($result) use ($quantity, &$kicked) {
+        $onSuccess = function (array $result) use ($quantity, &$kicked): bool {
             $stats = $result['response'];
             $buriedJobs = $stats['current-jobs-buried'] ?? 0;
 
@@ -274,6 +274,7 @@ class Pool implements ConnectionInterface
             if ($kicked >= $quantity) {
                 return false;
             }
+            return true;
         };
         $this->collection->sendToAll('statsTube', [$this->using], $onSuccess);
 
@@ -286,11 +287,12 @@ class Pool implements ConnectionInterface
     public function stats()
     {
         $stats = [];
-        $onSuccess = function ($result) use (&$stats) {
+        $onSuccess = function (array $result) use (&$stats): bool {
             if (!is_array($result['response'])) {
-                return;
+                return true;
             }
             $stats = $this->statsCombine($stats, $result['response']);
+            return true;
         };
         $this->collection->sendToAll('stats', [], $onSuccess);
 
@@ -320,11 +322,12 @@ class Pool implements ConnectionInterface
     public function statsTube($tube)
     {
         $stats = [];
-        $onSuccess = function ($result) use (&$stats) {
+        $onSuccess = function (array $result) use (&$stats): bool {
             if (!is_array($result['response'])) {
-                return;
+                return true;
             }
             $stats = $this->statsCombine($stats, $result['response']);
+            return true;
         };
         $this->collection->sendToAll('statsTube', [$tube], $onSuccess);
 
@@ -368,11 +371,12 @@ class Pool implements ConnectionInterface
     public function listTubes()
     {
         $tubes = [];
-        $onSuccess = function ($result) use (&$tubes) {
+        $onSuccess = function (array $result) use (&$tubes): bool {
             if (!is_array($result['response'])) {
-                return;
+                return true;
             }
             $tubes = array_merge($result['response'], $tubes);
+            return true;
         };
         $this->collection->sendToAll('listTubes', [], $onSuccess);
         return array_unique($tubes);

--- a/src/Pool/Collection.php
+++ b/src/Pool/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -14,24 +16,14 @@ use Phlib\Beanstalk\Exception\RuntimeException;
  */
 class Collection implements CollectionInterface
 {
-    /**
-     * @var array
-     */
-    protected $connections;
+    protected array $connections;
 
-    /**
-     * @var SelectionStrategyInterface
-     */
-    protected $strategy;
+    protected SelectionStrategyInterface $strategy;
 
-    /**
-     * @var array
-     */
-    protected $options;
+    protected array $options;
 
     /**
      * @param ConnectionInterface[] $connections
-     * @throws InvalidArgumentException
      */
     public function __construct(array $connections, SelectionStrategyInterface $strategy = null, array $options = [])
     {
@@ -57,18 +49,12 @@ class Collection implements CollectionInterface
         ];
     }
 
-    /**
-     * @return SelectionStrategyInterface
-     */
-    public function getSelectionStrategy()
+    public function getSelectionStrategy(): SelectionStrategyInterface
     {
         return $this->strategy;
     }
 
-    /**
-     * @return \Traversable
-     */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $connections = [];
         foreach (array_keys($this->connections) as $key) {
@@ -81,10 +67,7 @@ class Collection implements CollectionInterface
         return new \ArrayIterator($connections);
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getConnection($key)
+    public function getConnection(string $key): ConnectionInterface
     {
         if (!array_key_exists($key, $this->connections)) {
             throw new NotFoundException("Specified key '{$key}' is not in the pool.");
@@ -98,10 +81,7 @@ class Collection implements CollectionInterface
         return $this->connections[$key]['connection'];
     }
 
-    /**
-     * @return array
-     */
-    public function getAvailableKeys()
+    public function getAvailableKeys(): array
     {
         $keys = [];
         foreach (array_keys($this->connections) as $key) {
@@ -116,9 +96,9 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * @inheritdoc
+     * @return mixed
      */
-    public function sendToOne($command, array $arguments = [])
+    public function sendToOne(string $command, array $arguments = [])
     {
         $e = null;
 
@@ -151,9 +131,9 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * @inheritdoc
+     * @return mixed
      */
-    public function sendToExact($key, $command, array $arguments = [])
+    public function sendToExact(string $key, string $command, array $arguments = [])
     {
         try {
             $connection = $this->getConnection($key);
@@ -239,10 +219,21 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * @inheritdoc
+     * @param callable|null $success {
+     *     @param array $result
+     *     @return bool continue iteration to other connections
+     * }
+     * @param callable|null $failure {
+     *     @return bool continue iteration to other connections
+     * }
+     * @return mixed
      */
-    public function sendToAll($command, array $arguments = [], callable $success = null, callable $failure = null)
-    {
+    public function sendToAll(
+        string $command,
+        array $arguments = [],
+        callable $success = null,
+        callable $failure = null
+    ) {
         foreach (array_keys($this->connections) as $key) {
             try {
                 $result = $this->sendToExact($key, $command, $arguments);

--- a/src/Pool/Collection.php
+++ b/src/Pool/Collection.php
@@ -116,7 +116,7 @@ class Collection implements CollectionInterface
             }
 
             $keysUsed[$key] = true;
-            if (count($keysUsed) == count($keysAvailable)) {
+            if (count($keysUsed) === count($keysAvailable)) {
                 $keysExhausted = true;
             }
         }

--- a/src/Pool/Collection.php
+++ b/src/Pool/Collection.php
@@ -157,7 +157,72 @@ class Collection implements CollectionInterface
     {
         try {
             $connection = $this->getConnection($key);
-            $result = call_user_func_array([$connection, $command], $arguments);
+
+            // Use switch instead of `->{$command}` to allow static analysis
+            switch ($command) {
+                case 'useTube':
+                    $result = $connection->useTube(...$arguments);
+                    break;
+                case 'put':
+                    $result = $connection->put(...$arguments);
+                    break;
+                case 'reserve':
+                    $result = $connection->reserve(...$arguments);
+                    break;
+                case 'touch':
+                    $result = $connection->touch(...$arguments);
+                    break;
+                case 'release':
+                    $result = $connection->release(...$arguments);
+                    break;
+                case 'bury':
+                    $result = $connection->bury(...$arguments);
+                    break;
+                case 'delete':
+                    $result = $connection->delete(...$arguments);
+                    break;
+                case 'watch':
+                    $result = $connection->watch(...$arguments);
+                    break;
+                case 'ignore':
+                    $result = $connection->ignore(...$arguments);
+                    break;
+                case 'peek':
+                    $result = $connection->peek(...$arguments);
+                    break;
+                case 'statsJob':
+                    $result = $connection->statsJob(...$arguments);
+                    break;
+                case 'peekReady':
+                    $result = $connection->peekReady();
+                    break;
+                case 'peekDelayed':
+                    $result = $connection->peekDelayed();
+                    break;
+                case 'peekBuried':
+                    $result = $connection->peekBuried();
+                    break;
+                case 'kick':
+                    $result = $connection->kick(...$arguments);
+                    break;
+                case 'statsTube':
+                    $result = $connection->statsTube(...$arguments);
+                    break;
+                case 'stats':
+                    $result = $connection->stats();
+                    break;
+                case 'listTubes':
+                    $result = $connection->listTubes();
+                    break;
+                case 'listTubeUsed':
+                    $result = $connection->listTubeUsed();
+                    break;
+                case 'listTubesWatched':
+                    $result = $connection->listTubesWatched();
+                    break;
+                default:
+                    throw new InvalidArgumentException("Specified command '{$command}' is not allowed.");
+            }
             $this->connections[$key]['retry_at'] = false;
 
             return [

--- a/src/Pool/CollectionInterface.php
+++ b/src/Pool/CollectionInterface.php
@@ -36,8 +36,13 @@ interface CollectionInterface extends \IteratorAggregate
 
     /**
      * @param $command
-     * @param callable $success
-     * @param callable $failure
+     * @param callable|null $success {
+     *     @param array $result
+     *     @return bool continue iteration to other connections
+     * }
+     * @param callable|null $failure {
+     *     @return bool continue iteration to other connections
+     * }
      * @return mixed
      */
     public function sendToAll($command, array $arguments = [], callable $success = null, callable $failure = null);

--- a/src/Pool/CollectionInterface.php
+++ b/src/Pool/CollectionInterface.php
@@ -24,21 +24,18 @@ interface CollectionInterface extends \IteratorAggregate
     /**
      * @param $key
      * @param $command
-     * @param array $arguments
      * @return mixed
      */
     public function sendToExact($key, $command, array $arguments = []);
 
     /**
      * @param $command
-     * @param array $arguments
      * @return mixed
      */
     public function sendToOne($command, array $arguments = []);
 
     /**
      * @param $command
-     * @param array $arguments
      * @param callable $success
      * @param callable $failure
      * @return mixed

--- a/src/Pool/CollectionInterface.php
+++ b/src/Pool/CollectionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -10,32 +12,21 @@ use Phlib\Beanstalk\Connection\ConnectionInterface;
  */
 interface CollectionInterface extends \IteratorAggregate
 {
-    /**
-     * @return array
-     */
-    public function getAvailableKeys();
+    public function getAvailableKeys(): array;
+
+    public function getConnection(string $key): ConnectionInterface;
 
     /**
-     * @param string $key
-     * @return ConnectionInterface
-     */
-    public function getConnection($key);
-
-    /**
-     * @param $key
-     * @param $command
      * @return mixed
      */
-    public function sendToExact($key, $command, array $arguments = []);
+    public function sendToExact(string $key, string $command, array $arguments = []);
 
     /**
-     * @param $command
      * @return mixed
      */
-    public function sendToOne($command, array $arguments = []);
+    public function sendToOne(string $command, array $arguments = []);
 
     /**
-     * @param $command
      * @param callable|null $success {
      *     @param array $result
      *     @return bool continue iteration to other connections
@@ -45,5 +36,10 @@ interface CollectionInterface extends \IteratorAggregate
      * }
      * @return mixed
      */
-    public function sendToAll($command, array $arguments = [], callable $success = null, callable $failure = null);
+    public function sendToAll(
+        string $command,
+        array $arguments = [],
+        callable $success = null,
+        callable $failure = null
+    );
 }

--- a/src/Pool/RandomStrategy.php
+++ b/src/Pool/RandomStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -11,9 +13,9 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
 class RandomStrategy implements SelectionStrategyInterface
 {
     /**
-     * @inheritdoc
+     * @param string[] $collection
      */
-    public function pickOne(array $collection)
+    public function pickOne(array $collection): string
     {
         if (empty($collection)) {
             throw new InvalidArgumentException('Can not select from an empty collection.');

--- a/src/Pool/RandomStrategy.php
+++ b/src/Pool/RandomStrategy.php
@@ -20,7 +20,7 @@ class RandomStrategy implements SelectionStrategyInterface
         if (empty($collection)) {
             throw new InvalidArgumentException('Can not select from an empty collection.');
         }
-        if (count($collection) == 1) {
+        if (count($collection) === 1) {
             return current($collection);
         }
 

--- a/src/Pool/RoundRobinStrategy.php
+++ b/src/Pool/RoundRobinStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -10,15 +12,12 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
  */
 class RoundRobinStrategy implements SelectionStrategyInterface
 {
-    /**
-     * @var integer
-     */
-    protected $index = -1;
+    protected int $index = -1;
 
     /**
-     * @inheritdoc
+     * @param string[] $collection
      */
-    public function pickOne(array $collection)
+    public function pickOne(array $collection): string
     {
         if (empty($collection)) {
             throw new InvalidArgumentException('Can not select from an empty collection.');

--- a/src/Pool/SelectionStrategyInterface.php
+++ b/src/Pool/SelectionStrategyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 /**
@@ -10,7 +12,6 @@ interface SelectionStrategyInterface
 {
     /**
      * @param string[] $collection
-     * @return string
      */
-    public function pickOne(array $collection);
+    public function pickOne(array $collection): string;
 }

--- a/src/StatsService.php
+++ b/src/StatsService.php
@@ -6,10 +6,13 @@ use Phlib\Beanstalk\Connection\ConnectionInterface;
 
 class StatsService
 {
-    public const SERVER_BINLOG  = 1;
+    public const SERVER_BINLOG = 1;
+
     public const SERVER_COMMAND = 2;
+
     public const SERVER_CURRENT = 4;
-    public const SERVER_ALL     = 7;
+
+    public const SERVER_ALL = 7;
 
     public const TUBE_HEADER_MAPPING = [
         'name' => 'Tube',
@@ -89,9 +92,6 @@ class StatsService
      */
     protected $stats;
 
-    /**
-     * @param ConnectionInterface $beanstalk
-     */
     public function __construct(ConnectionInterface $beanstalk)
     {
         $this->beanstalk = $beanstalk;
@@ -164,7 +164,7 @@ class StatsService
      */
     public function getAllTubeStats()
     {
-        $tubes     = $this->beanstalk->listTubes();
+        $tubes = $this->beanstalk->listTubes();
         $tubeStats = [];
         foreach ($tubes as $tube) {
             $stats = $this->beanstalk->statsTube($tube);
@@ -183,7 +183,6 @@ class StatsService
     }
 
     /**
-     * @param array $keys
      * @param $data
      * @return array
      */

--- a/src/StatsService.php
+++ b/src/StatsService.php
@@ -114,7 +114,7 @@ class StatsService
     protected function filterServerKeys($filter): array
     {
         $serverKeys = self::SERVER_KEYS;
-        if ($filter != self::SERVER_ALL) {
+        if ($filter !== self::SERVER_ALL) {
             $include = [];
             if ($filter & self::SERVER_BINLOG) {
                 $include[] = 'binlog-';
@@ -128,7 +128,7 @@ class StatsService
             $filtered = [];
             foreach ($include as $beginsWith) {
                 foreach ($serverKeys as $serverKey) {
-                    if (substr($serverKey, 0, strlen($beginsWith)) != $beginsWith) {
+                    if (substr($serverKey, 0, strlen($beginsWith)) !== $beginsWith) {
                         continue;
                     }
                     $filtered[] = $serverKey;

--- a/src/StatsService.php
+++ b/src/StatsService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -82,10 +84,7 @@ class StatsService
         'binlog-max-size',
     ];
 
-    /**
-     * @var ConnectionInterface
-     */
-    private $beanstalk;
+    private ConnectionInterface $beanstalk;
 
     /**
      * @var array
@@ -97,19 +96,12 @@ class StatsService
         $this->beanstalk = $beanstalk;
     }
 
-    /**
-     * @return array
-     */
-    public function getServerInfo()
+    public function getServerInfo(): array
     {
         return $this->filterTheseKeys(self::INFO_KEYS, $this->getStats());
     }
 
-    /**
-     * @param int $filter
-     * @return array
-     */
-    public function getServerStats($filter = self::SERVER_ALL)
+    public function getServerStats(int $filter = self::SERVER_ALL): array
     {
         $serverKeys = $this->filterServerKeys($filter);
         $stats = $this->filterTheseKeys($serverKeys, $this->getStats());
@@ -118,9 +110,8 @@ class StatsService
 
     /**
      * @param $filter
-     * @return array
      */
-    protected function filterServerKeys($filter)
+    protected function filterServerKeys($filter): array
     {
         $serverKeys = self::SERVER_KEYS;
         if ($filter != self::SERVER_ALL) {
@@ -148,21 +139,14 @@ class StatsService
         return $serverKeys;
     }
 
-    /**
-     * @param string $tube
-     * @return array
-     */
-    public function getTubeStats($tube)
+    public function getTubeStats(string $tube): array
     {
         $stats = $this->beanstalk->statsTube($tube);
         unset($stats['name']);
         return $stats;
     }
 
-    /**
-     * @return array
-     */
-    public function getAllTubeStats()
+    public function getAllTubeStats(): array
     {
         $tubes = $this->beanstalk->listTubes();
         $tubeStats = [];
@@ -184,17 +168,13 @@ class StatsService
 
     /**
      * @param $data
-     * @return array
      */
-    protected function filterTheseKeys(array $keys, $data)
+    protected function filterTheseKeys(array $keys, $data): array
     {
         return array_intersect_key($data, array_flip($keys));
     }
 
-    /**
-     * @return array
-     */
-    protected function getStats()
+    protected function getStats(): array
     {
         if (!$this->stats) {
             $this->stats = $this->beanstalk->stats();

--- a/src/ValidateTrait.php
+++ b/src/ValidateTrait.php
@@ -18,7 +18,12 @@ trait ValidateTrait
      */
     public function validatePriority($priority)
     {
-        $options = ['options' => ['min_range' => 0, 'max_range' => ConnectionInterface::MAX_PRIORITY]];
+        $options = [
+            'options' => [
+                'min_range' => 0,
+                'max_range' => ConnectionInterface::MAX_PRIORITY,
+            ],
+        ];
         if (filter_var($priority, FILTER_VALIDATE_INT, $options) === false) {
             throw new InvalidArgumentException('Priority is not within acceptable range.');
         }
@@ -32,10 +37,15 @@ trait ValidateTrait
      */
     public function validateTubeName($name)
     {
-        $bytes   = strlen($name);
-        $options = ['options' => ['min_range' => 1, 'max_range' => ConnectionInterface::MAX_TUBE_LENGTH]];
+        $bytes = strlen($name);
+        $options = [
+            'options' => [
+                'min_range' => 1,
+                'max_range' => ConnectionInterface::MAX_TUBE_LENGTH,
+            ],
+        ];
         if (filter_var($bytes, FILTER_VALIDATE_INT, $options) === false) {
-            throw new InvalidArgumentException("Specified tube '$name' is not a valid name.");
+            throw new InvalidArgumentException("Specified tube '{$name}' is not a valid name.");
         }
         return true;
     }
@@ -55,9 +65,14 @@ trait ValidateTrait
                 $data = 'Object';
             }
         }
-        $options = ['options' => ['min_range' => 1, 'max_range' => ConnectionInterface::MAX_JOB_LENGTH]];
+        $options = [
+            'options' => [
+                'min_range' => 1,
+                'max_range' => ConnectionInterface::MAX_JOB_LENGTH,
+            ],
+        ];
         if (filter_var(strlen($data), FILTER_VALIDATE_INT, $options) === false) {
-            throw new InvalidArgumentException("The job data is too large. Maximum allowed size is 65,536.");
+            throw new InvalidArgumentException('The job data is too large. Maximum allowed size is 65,536.');
         }
         return true;
     }

--- a/src/ValidateTrait.php
+++ b/src/ValidateTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -11,12 +13,7 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
  */
 trait ValidateTrait
 {
-    /**
-     * @param integer $priority
-     * @return true
-     * @throws InvalidArgumentException
-     */
-    public function validatePriority($priority)
+    public function validatePriority(int $priority): bool
     {
         $options = [
             'options' => [
@@ -30,12 +27,7 @@ trait ValidateTrait
         return true;
     }
 
-    /**
-     * @param string $name
-     * @return true
-     * @throws InvalidArgumentException
-     */
-    public function validateTubeName($name)
+    public function validateTubeName(string $name): bool
     {
         $bytes = strlen($name);
         $options = [
@@ -52,9 +44,8 @@ trait ValidateTrait
 
     /**
      * @param mixed $data
-     * @return true
      */
-    public function validateJobData($data)
+    public function validateJobData($data): bool
     {
         if (is_array($data)) {
             $data = 'Array';
@@ -71,7 +62,7 @@ trait ValidateTrait
                 'max_range' => ConnectionInterface::MAX_JOB_LENGTH,
             ],
         ];
-        if (filter_var(strlen($data), FILTER_VALIDATE_INT, $options) === false) {
+        if (filter_var(strlen((string)$data), FILTER_VALIDATE_INT, $options) === false) {
             throw new InvalidArgumentException('The job data is too large. Maximum allowed size is 65,536.');
         }
         return true;

--- a/tests/Command/BuryTest.php
+++ b/tests/Command/BuryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -7,19 +9,19 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class BuryTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Bury(123, 123));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $id = 123;
         $priority = 1;
         static::assertEquals("bury {$id} {$priority}", (new Bury($id, $priority))->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -27,7 +29,7 @@ class BuryTest extends CommandTestCase
         static::assertInstanceOf(Bury::class, (new Bury(123, 123))->process($this->socket));
     }
 
-    public function testNotFoundThrowsException()
+    public function testNotFoundThrowsException(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -37,7 +39,7 @@ class BuryTest extends CommandTestCase
         (new Bury(123, 123))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/BuryTest.php
+++ b/tests/Command/BuryTest.php
@@ -16,7 +16,7 @@ class BuryTest extends CommandTestCase
     {
         $id = 123;
         $priority = 1;
-        static::assertEquals("bury $id $priority", (new Bury($id, $priority))->getCommand());
+        static::assertEquals("bury {$id} {$priority}", (new Bury($id, $priority))->getCommand());
     }
 
     public function testSuccessfulCommand()

--- a/tests/Command/BuryTest.php
+++ b/tests/Command/BuryTest.php
@@ -18,7 +18,7 @@ class BuryTest extends CommandTestCase
     {
         $id = 123;
         $priority = 1;
-        static::assertEquals("bury {$id} {$priority}", (new Bury($id, $priority))->getCommand());
+        static::assertSame("bury {$id} {$priority}", (new Bury($id, $priority))->getCommand());
     }
 
     public function testSuccessfulCommand(): void

--- a/tests/Command/CommandTestCase.php
+++ b/tests/Command/CommandTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\SocketInterface;
@@ -11,17 +13,11 @@ class CommandTestCase extends TestCase
     /**
      * @var SocketInterface|MockObject
      */
-    protected $socket;
+    protected MockObject $socket;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->socket = $this->getMockForAbstractClass(SocketInterface::class);
-    }
-
-    protected function tearDown()
-    {
-        $this->socket = null;
-        parent::tearDown();
     }
 }

--- a/tests/Command/DeleteTest.php
+++ b/tests/Command/DeleteTest.php
@@ -17,7 +17,7 @@ class DeleteTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $id = 123;
-        static::assertEquals("delete {$id}", (new Delete($id))->getCommand());
+        static::assertSame("delete {$id}", (new Delete($id))->getCommand());
     }
 
     public function testSuccessfulCommand(): void

--- a/tests/Command/DeleteTest.php
+++ b/tests/Command/DeleteTest.php
@@ -15,7 +15,7 @@ class DeleteTest extends CommandTestCase
     public function testGetCommand()
     {
         $id = 123;
-        static::assertEquals("delete $id", (new Delete($id))->getCommand());
+        static::assertEquals("delete {$id}", (new Delete($id))->getCommand());
     }
 
     public function testSuccessfulCommand()

--- a/tests/Command/DeleteTest.php
+++ b/tests/Command/DeleteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -7,18 +9,18 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class DeleteTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Delete(123));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $id = 123;
         static::assertEquals("delete {$id}", (new Delete($id))->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -26,7 +28,7 @@ class DeleteTest extends CommandTestCase
         static::assertInstanceOf(Delete::class, (new Delete(123))->process($this->socket));
     }
 
-    public function testNotFoundThrowsException()
+    public function testNotFoundThrowsException(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -36,7 +38,7 @@ class DeleteTest extends CommandTestCase
         (new Delete(123))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/IgnoreTest.php
+++ b/tests/Command/IgnoreTest.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
 
 class IgnoreTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Ignore('test-tube'));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $tube = 'test-tube';
         static::assertEquals("ignore {$tube}", (new Ignore($tube))->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -25,7 +27,7 @@ class IgnoreTest extends CommandTestCase
         static::assertInternalType('int', (new Ignore('test-tube'))->process($this->socket));
     }
 
-    public function testNotFoundThrowsException()
+    public function testNotFoundThrowsException(): void
     {
         $this->expectException(CommandException::class);
 
@@ -35,7 +37,7 @@ class IgnoreTest extends CommandTestCase
         (new Ignore('test-tube'))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/IgnoreTest.php
+++ b/tests/Command/IgnoreTest.php
@@ -14,7 +14,7 @@ class IgnoreTest extends CommandTestCase
     public function testGetCommand()
     {
         $tube = 'test-tube';
-        static::assertEquals("ignore $tube", (new Ignore($tube))->getCommand());
+        static::assertEquals("ignore {$tube}", (new Ignore($tube))->getCommand());
     }
 
     public function testSuccessfulCommand()

--- a/tests/Command/IgnoreTest.php
+++ b/tests/Command/IgnoreTest.php
@@ -16,7 +16,7 @@ class IgnoreTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $tube = 'test-tube';
-        static::assertEquals("ignore {$tube}", (new Ignore($tube))->getCommand());
+        static::assertSame("ignore {$tube}", (new Ignore($tube))->getCommand());
     }
 
     public function testSuccessfulCommand(): void

--- a/tests/Command/KickTest.php
+++ b/tests/Command/KickTest.php
@@ -14,7 +14,7 @@ class KickTest extends CommandTestCase
     public function testGetCommand()
     {
         $bound = 10;
-        static::assertEquals("kick $bound", (new Kick($bound))->getCommand());
+        static::assertEquals("kick {$bound}", (new Kick($bound))->getCommand());
     }
 
     public function testSuccessfulCommand()

--- a/tests/Command/KickTest.php
+++ b/tests/Command/KickTest.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
 
 class KickTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Kick(10));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $bound = 10;
         static::assertEquals("kick {$bound}", (new Kick($bound))->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -25,7 +27,7 @@ class KickTest extends CommandTestCase
         static::assertInternalType('int', (new Kick(10))->process($this->socket));
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/KickTest.php
+++ b/tests/Command/KickTest.php
@@ -16,7 +16,7 @@ class KickTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $bound = 10;
-        static::assertEquals("kick {$bound}", (new Kick($bound))->getCommand());
+        static::assertSame("kick {$bound}", (new Kick($bound))->getCommand());
     }
 
     public function testSuccessfulCommand(): void

--- a/tests/Command/ListTubeUsedTest.php
+++ b/tests/Command/ListTubeUsedTest.php
@@ -13,7 +13,7 @@ class ListTubeUsedTest extends CommandTestCase
 
     public function testGetCommand()
     {
-        static::assertEquals("list-tube-used", (new ListTubeUsed())->getCommand());
+        static::assertEquals('list-tube-used', (new ListTubeUsed())->getCommand());
     }
 
     public function testSuccessfulCommand()
@@ -21,7 +21,7 @@ class ListTubeUsedTest extends CommandTestCase
         $tube = 'test-tube';
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturn("USING $tube");
+            ->willReturn("USING {$tube}");
         static::assertEquals($tube, (new ListTubeUsed())->process($this->socket));
     }
 

--- a/tests/Command/ListTubeUsedTest.php
+++ b/tests/Command/ListTubeUsedTest.php
@@ -15,7 +15,7 @@ class ListTubeUsedTest extends CommandTestCase
 
     public function testGetCommand(): void
     {
-        static::assertEquals('list-tube-used', (new ListTubeUsed())->getCommand());
+        static::assertSame('list-tube-used', (new ListTubeUsed())->getCommand());
     }
 
     public function testSuccessfulCommand(): void
@@ -24,7 +24,7 @@ class ListTubeUsedTest extends CommandTestCase
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn("USING {$tube}");
-        static::assertEquals($tube, (new ListTubeUsed())->process($this->socket));
+        static::assertSame($tube, (new ListTubeUsed())->process($this->socket));
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/Command/ListTubeUsedTest.php
+++ b/tests/Command/ListTubeUsedTest.php
@@ -1,22 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
 
 class ListTubeUsedTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new ListTubeUsed());
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         static::assertEquals('list-tube-used', (new ListTubeUsed())->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $tube = 'test-tube';
         $this->socket->expects(static::any())
@@ -25,7 +27,7 @@ class ListTubeUsedTest extends CommandTestCase
         static::assertEquals($tube, (new ListTubeUsed())->process($this->socket));
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/ListTubesTest.php
+++ b/tests/Command/ListTubesTest.php
@@ -13,6 +13,6 @@ class ListTubesTest extends CommandTestCase
 
     public function testGetCommand(): void
     {
-        static::assertEquals('list-tubes', (new ListTubes())->getCommand());
+        static::assertSame('list-tubes', (new ListTubes())->getCommand());
     }
 }

--- a/tests/Command/ListTubesTest.php
+++ b/tests/Command/ListTubesTest.php
@@ -11,6 +11,6 @@ class ListTubesTest extends CommandTestCase
 
     public function testGetCommand()
     {
-        static::assertEquals("list-tubes", (new ListTubes())->getCommand());
+        static::assertEquals('list-tubes', (new ListTubes())->getCommand());
     }
 }

--- a/tests/Command/ListTubesTest.php
+++ b/tests/Command/ListTubesTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 class ListTubesTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new ListTubes());
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         static::assertEquals('list-tubes', (new ListTubes())->getCommand());
     }

--- a/tests/Command/ListTubesWatchedTest.php
+++ b/tests/Command/ListTubesWatchedTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 class ListTubesWatchedTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new ListTubesWatched());
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         static::assertEquals('list-tubes-watched', (new ListTubesWatched())->getCommand());
     }

--- a/tests/Command/ListTubesWatchedTest.php
+++ b/tests/Command/ListTubesWatchedTest.php
@@ -11,6 +11,6 @@ class ListTubesWatchedTest extends CommandTestCase
 
     public function testGetCommand()
     {
-        static::assertEquals("list-tubes-watched", (new ListTubesWatched())->getCommand());
+        static::assertEquals('list-tubes-watched', (new ListTubesWatched())->getCommand());
     }
 }

--- a/tests/Command/ListTubesWatchedTest.php
+++ b/tests/Command/ListTubesWatchedTest.php
@@ -13,6 +13,6 @@ class ListTubesWatchedTest extends CommandTestCase
 
     public function testGetCommand(): void
     {
-        static::assertEquals('list-tubes-watched', (new ListTubesWatched())->getCommand());
+        static::assertSame('list-tubes-watched', (new ListTubesWatched())->getCommand());
     }
 }

--- a/tests/Command/PeekStatusTest.php
+++ b/tests/Command/PeekStatusTest.php
@@ -5,18 +5,40 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use Phlib\Beanstalk\Exception\NotFoundException;
 
-class PeekTest extends CommandTestCase
+class PeekStatusTest extends CommandTestCase
 {
     public function testImplementsCommand()
     {
-        static::assertInstanceOf(CommandInterface::class, new Peek(10));
+        static::assertInstanceOf(CommandInterface::class, new PeekStatus('ready'));
     }
 
-    public function testGetCommand()
+    /**
+     * @param mixed $subject
+     * @param string $command
+     * @dataProvider getCommandDataProvider
+     */
+    public function testGetCommand($subject, $command)
     {
-        static::assertEquals('peek 123', (new Peek(123))->getCommand());
+        static::assertEquals($command, (new PeekStatus($subject))->getCommand());
+    }
+
+    public function getCommandDataProvider()
+    {
+        return [
+            ['ready', 'peek-ready'],
+            ['delayed', 'peek-delayed'],
+            ['buried', 'peek-buried'],
+        ];
+    }
+
+    public function testWithInvalidSubject()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PeekStatus('foo-bar');
     }
 
     public function testSuccessfulCommand()
@@ -32,7 +54,7 @@ class PeekTest extends CommandTestCase
             ->method('read')
             ->willReturnOnConsecutiveCalls("FOUND {$id} 54\r\n", $body . "\r\n");
 
-        static::assertEquals($response, (new Peek(10))->process($this->socket));
+        static::assertEquals($response, (new PeekStatus(PeekStatus::BURIED))->process($this->socket));
     }
 
     public function testNotFoundThrowsException()
@@ -42,7 +64,7 @@ class PeekTest extends CommandTestCase
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('NOT_FOUND');
-        (new Peek(10))->process($this->socket);
+        (new PeekStatus(PeekStatus::BURIED))->process($this->socket);
     }
 
     public function testUnknownStatusThrowsException()
@@ -52,6 +74,6 @@ class PeekTest extends CommandTestCase
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('UNKNOWN_ERROR');
-        (new Peek(10))->process($this->socket);
+        (new PeekStatus(PeekStatus::BURIED))->process($this->socket);
     }
 }

--- a/tests/Command/PeekStatusTest.php
+++ b/tests/Command/PeekStatusTest.php
@@ -22,7 +22,7 @@ class PeekStatusTest extends CommandTestCase
      */
     public function testGetCommand($subject, $command)
     {
-        static::assertEquals($command, (new PeekStatus($subject))->getCommand());
+        static::assertSame($command, (new PeekStatus($subject))->getCommand());
     }
 
     public function getCommandDataProvider()
@@ -54,7 +54,7 @@ class PeekStatusTest extends CommandTestCase
             ->method('read')
             ->willReturnOnConsecutiveCalls("FOUND {$id} 54\r\n", $body . "\r\n");
 
-        static::assertEquals($response, (new PeekStatus(PeekStatus::BURIED))->process($this->socket));
+        static::assertSame($response, (new PeekStatus(PeekStatus::BURIED))->process($this->socket));
     }
 
     public function testNotFoundThrowsException()

--- a/tests/Command/PeekTest.php
+++ b/tests/Command/PeekTest.php
@@ -42,13 +42,16 @@ class PeekTest extends CommandTestCase
 
     public function testSuccessfulCommand()
     {
-        $id       = 123;
-        $body     = 'Foo Bar';
-        $response = ['id' => $id, 'body' => $body];
+        $id = 123;
+        $body = 'Foo Bar';
+        $response = [
+            'id' => $id,
+            'body' => $body,
+        ];
 
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturnOnConsecutiveCalls("FOUND $id 123\r\n", $body . "\r\n");
+            ->willReturnOnConsecutiveCalls("FOUND {$id} 123\r\n", $body . "\r\n");
 
         static::assertEquals($response, (new Peek(10))->process($this->socket));
     }

--- a/tests/Command/PeekTest.php
+++ b/tests/Command/PeekTest.php
@@ -16,7 +16,7 @@ class PeekTest extends CommandTestCase
 
     public function testGetCommand(): void
     {
-        static::assertEquals('peek 123', (new Peek(123))->getCommand());
+        static::assertSame('peek 123', (new Peek(123))->getCommand());
     }
 
     public function testSuccessfulCommand(): void
@@ -32,7 +32,7 @@ class PeekTest extends CommandTestCase
             ->method('read')
             ->willReturnOnConsecutiveCalls("FOUND {$id} 54\r\n", $body . "\r\n");
 
-        static::assertEquals($response, (new Peek(10))->process($this->socket));
+        static::assertSame($response, (new Peek(10))->process($this->socket));
     }
 
     public function testNotFoundThrowsException(): void

--- a/tests/Command/PeekTest.php
+++ b/tests/Command/PeekTest.php
@@ -9,17 +9,17 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class PeekTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Peek(10));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         static::assertEquals('peek 123', (new Peek(123))->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $id = 123;
         $body = 'Foo Bar';
@@ -35,7 +35,7 @@ class PeekTest extends CommandTestCase
         static::assertEquals($response, (new Peek(10))->process($this->socket));
     }
 
-    public function testNotFoundThrowsException()
+    public function testNotFoundThrowsException(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -45,7 +45,7 @@ class PeekTest extends CommandTestCase
         (new Peek(10))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/PutTest.php
+++ b/tests/Command/PutTest.php
@@ -18,7 +18,7 @@ class PutTest extends CommandTestCase
     {
         $data = 'data';
         $bytes = strlen($data);
-        static::assertEquals("put 123 456 789 {$bytes}", (new Put($data, 123, 456, 789))->getCommand());
+        static::assertSame("put 123 456 789 {$bytes}", (new Put($data, 123, 456, 789))->getCommand());
     }
 
     public function testWithInvalidPriority(): void
@@ -36,7 +36,7 @@ class PutTest extends CommandTestCase
             ->method('read')
             ->willReturn("INSERTED {$id}");
 
-        static::assertEquals($id, (new Put('data', 123, 456, 789))->process($this->socket));
+        static::assertSame($id, (new Put('data', 123, 456, 789))->process($this->socket));
     }
 
     public function testErrorThrowsException(): void

--- a/tests/Command/PutTest.php
+++ b/tests/Command/PutTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -7,26 +9,27 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 class PutTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Put('data', 1, 0, 60));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $data = 'data';
         $bytes = strlen($data);
         static::assertEquals("put 123 456 789 {$bytes}", (new Put($data, 123, 456, 789))->getCommand());
     }
 
-    public function testWithInvalidPriority()
+    public function testWithInvalidPriority(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new Put('data', 'foo', 123, 456);
+        // Priority must be integer between 0 and 4,294,967,295
+        new Put('data', 4294967296, 123, 456);
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $id = 123;
         $this->socket->expects(static::any())
@@ -36,7 +39,7 @@ class PutTest extends CommandTestCase
         static::assertEquals($id, (new Put('data', 123, 456, 789))->process($this->socket));
     }
 
-    public function testErrorThrowsException()
+    public function testErrorThrowsException(): void
     {
         $this->expectException(CommandException::class);
 
@@ -46,7 +49,7 @@ class PutTest extends CommandTestCase
         (new Put('data', 123, 456, 789))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/PutTest.php
+++ b/tests/Command/PutTest.php
@@ -14,9 +14,9 @@ class PutTest extends CommandTestCase
 
     public function testGetCommand()
     {
-        $data  = 'data';
+        $data = 'data';
         $bytes = strlen($data);
-        static::assertEquals("put 123 456 789 $bytes", (new Put($data, 123, 456, 789))->getCommand());
+        static::assertEquals("put 123 456 789 {$bytes}", (new Put($data, 123, 456, 789))->getCommand());
     }
 
     public function testWithInvalidPriority()
@@ -31,7 +31,7 @@ class PutTest extends CommandTestCase
         $id = 123;
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturn("INSERTED $id");
+            ->willReturn("INSERTED {$id}");
 
         static::assertEquals($id, (new Put('data', 123, 456, 789))->process($this->socket));
     }

--- a/tests/Command/ReleaseTest.php
+++ b/tests/Command/ReleaseTest.php
@@ -17,7 +17,7 @@ class ReleaseTest extends CommandTestCase
 
     public function testGetCommand(): void
     {
-        static::assertEquals('release 123 456 789', (new Release(123, 456, 789))->getCommand());
+        static::assertSame('release 123 456 789', (new Release(123, 456, 789))->getCommand());
     }
 
     public function testWithInvalidPriority(): void

--- a/tests/Command/ReleaseTest.php
+++ b/tests/Command/ReleaseTest.php
@@ -29,7 +29,7 @@ class ReleaseTest extends CommandTestCase
     {
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturn("RELEASED");
+            ->willReturn('RELEASED');
 
         $release = new Release(123, 456, 789);
         static::assertInstanceOf(Release::class, $release->process($this->socket));

--- a/tests/Command/ReleaseTest.php
+++ b/tests/Command/ReleaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -8,24 +10,25 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class ReleaseTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Release(123, 456, 789));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         static::assertEquals('release 123 456 789', (new Release(123, 456, 789))->getCommand());
     }
 
-    public function testWithInvalidPriority()
+    public function testWithInvalidPriority(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new Release(123, 'foo', 456);
+        // Priority must be integer between 0 and 4,294,967,295
+        new Release(123, 4294967296, 456);
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -35,7 +38,7 @@ class ReleaseTest extends CommandTestCase
         static::assertInstanceOf(Release::class, $release->process($this->socket));
     }
 
-    public function testNotFoundThrowsException()
+    public function testNotFoundThrowsException(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -45,7 +48,7 @@ class ReleaseTest extends CommandTestCase
         (new Release(123, 456, 789))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/ReserveTest.php
+++ b/tests/Command/ReserveTest.php
@@ -18,7 +18,7 @@ class ReserveTest extends CommandTestCase
      */
     public function testGetCommand(?int $timeout, string $command): void
     {
-        static::assertEquals($command, (new Reserve($timeout))->getCommand());
+        static::assertSame($command, (new Reserve($timeout))->getCommand());
     }
 
     public function getCommandDataProvider(): array
@@ -43,7 +43,7 @@ class ReserveTest extends CommandTestCase
             ->method('read')
             ->willReturnOnConsecutiveCalls("RESERVED {$id} {$bytes}\r\n", $data . "\r\n");
 
-        static::assertEquals($response, (new Reserve())->process($this->socket));
+        static::assertSame($response, (new Reserve())->process($this->socket));
     }
 
     /**

--- a/tests/Command/ReserveTest.php
+++ b/tests/Command/ReserveTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
 
 class ReserveTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Reserve(123));
     }
@@ -14,12 +16,12 @@ class ReserveTest extends CommandTestCase
     /**
      * @dataProvider getCommandDataProvider
      */
-    public function testGetCommand($timeout, $command)
+    public function testGetCommand(?int $timeout, string $command): void
     {
         static::assertEquals($command, (new Reserve($timeout))->getCommand());
     }
 
-    public function getCommandDataProvider()
+    public function getCommandDataProvider(): array
     {
         return [
             [123, 'reserve-with-timeout 123'],
@@ -27,7 +29,7 @@ class ReserveTest extends CommandTestCase
         ];
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $id = 123;
         $data = 'Foo Bar';
@@ -45,10 +47,9 @@ class ReserveTest extends CommandTestCase
     }
 
     /**
-     * @param string $status
      * @dataProvider failureStatusReturnsFalseDataProvider
      */
-    public function testFailureStatusReturnsFalse($status)
+    public function testFailureStatusReturnsFalse(string $status): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -56,7 +57,7 @@ class ReserveTest extends CommandTestCase
         static::assertFalse((new Reserve(123))->process($this->socket));
     }
 
-    public function failureStatusReturnsFalseDataProvider()
+    public function failureStatusReturnsFalseDataProvider(): array
     {
         return [
             ['TIMED_OUT'],
@@ -64,7 +65,7 @@ class ReserveTest extends CommandTestCase
         ];
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/ReserveTest.php
+++ b/tests/Command/ReserveTest.php
@@ -29,14 +29,17 @@ class ReserveTest extends CommandTestCase
 
     public function testSuccessfulCommand()
     {
-        $id       = 123;
-        $data     = 'Foo Bar';
-        $bytes    = strlen($data);
-        $response = ['id' => $id, 'body' => $data];
+        $id = 123;
+        $data = 'Foo Bar';
+        $bytes = strlen($data);
+        $response = [
+            'id' => $id,
+            'body' => $data,
+        ];
 
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturnOnConsecutiveCalls("RESERVED $id $bytes\r\n", $data . "\r\n");
+            ->willReturnOnConsecutiveCalls("RESERVED {$id} {$bytes}\r\n", $data . "\r\n");
 
         static::assertEquals($response, (new Reserve())->process($this->socket));
     }

--- a/tests/Command/StatsJobTest.php
+++ b/tests/Command/StatsJobTest.php
@@ -14,6 +14,6 @@ class StatsJobTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $id = 123;
-        static::assertEquals("stats-job {$id}", (new StatsJob($id))->getCommand());
+        static::assertSame("stats-job {$id}", (new StatsJob($id))->getCommand());
     }
 }

--- a/tests/Command/StatsJobTest.php
+++ b/tests/Command/StatsJobTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 class StatsJobTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new StatsJob(123));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $id = 123;
         static::assertEquals("stats-job {$id}", (new StatsJob($id))->getCommand());

--- a/tests/Command/StatsJobTest.php
+++ b/tests/Command/StatsJobTest.php
@@ -12,6 +12,6 @@ class StatsJobTest extends CommandTestCase
     public function testGetCommand()
     {
         $id = 123;
-        static::assertEquals("stats-job $id", (new StatsJob($id))->getCommand());
+        static::assertEquals("stats-job {$id}", (new StatsJob($id))->getCommand());
     }
 }

--- a/tests/Command/StatsTest.php
+++ b/tests/Command/StatsTest.php
@@ -13,6 +13,6 @@ class StatsTest extends CommandTestCase
 
     public function testGetCommand(): void
     {
-        static::assertEquals('stats', (new Stats())->getCommand());
+        static::assertSame('stats', (new Stats())->getCommand());
     }
 }

--- a/tests/Command/StatsTest.php
+++ b/tests/Command/StatsTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 class StatsTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Stats());
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         static::assertEquals('stats', (new Stats())->getCommand());
     }

--- a/tests/Command/StatsTraitTest.php
+++ b/tests/Command/StatsTraitTest.php
@@ -24,7 +24,7 @@ class StatsTraitTest extends CommandTestCase
             ->method('decode')
             ->willReturn([$testString]);
 
-        static::assertEquals($expectedData, $stat->process($this->socket));
+        static::assertSame($expectedData, $stat->process($this->socket));
     }
 
     public function testWhenStatusNotFound(): void
@@ -58,7 +58,7 @@ class StatsTraitTest extends CommandTestCase
             ->method('read')
             ->willReturnOnConsecutiveCalls("OK 1234\r\n", "---\n{$yaml}\r\n");
         $stat = $this->getMockStat(['process', 'decode']);
-        static::assertEquals($expectedOutput, $stat->process($this->socket));
+        static::assertSame($expectedOutput, $stat->process($this->socket));
     }
 
     public function yamlFormatIsDecodedDataProvider(): array

--- a/tests/Command/StatsTraitTest.php
+++ b/tests/Command/StatsTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -8,7 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class StatsTraitTest extends CommandTestCase
 {
-    public function testProcessCompletesOnSuccess()
+    public function testProcessCompletesOnSuccess(): void
     {
         $stat = $this->getMockStat(['process']);
         $testString = 'my test data';
@@ -25,7 +27,7 @@ class StatsTraitTest extends CommandTestCase
         static::assertEquals($expectedData, $stat->process($this->socket));
     }
 
-    public function testWhenStatusNotFound()
+    public function testWhenStatusNotFound(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -36,7 +38,7 @@ class StatsTraitTest extends CommandTestCase
             ->process($this->socket);
     }
 
-    public function testWhenStatusUnknown()
+    public function testWhenStatusUnknown(): void
     {
         $this->expectException(CommandException::class);
 
@@ -48,10 +50,9 @@ class StatsTraitTest extends CommandTestCase
     }
 
     /**
-     * @param string $yaml
      * @dataProvider yamlFormatIsDecodedDataProvider
      */
-    public function testYamlFormatIsDecoded($yaml, array $expectedOutput)
+    public function testYamlFormatIsDecoded(string $yaml, array $expectedOutput): void
     {
         $this->socket->expects(static::any())
             ->method('read')
@@ -60,7 +61,7 @@ class StatsTraitTest extends CommandTestCase
         static::assertEquals($expectedOutput, $stat->process($this->socket));
     }
 
-    public function yamlFormatIsDecodedDataProvider()
+    public function yamlFormatIsDecodedDataProvider(): array
     {
         return [
             [
@@ -115,11 +116,15 @@ class StatsTraitTest extends CommandTestCase
     /**
      * @return StatsTrait|MockObject
      */
-    public function getMockStat(array $mockFns)
+    public function getMockStat(array $mockFns): MockObject
     {
         $availableFns = ['process', 'decode', 'getCommand'];
-        return $this->getMockBuilder(StatsTrait::class)
+        $mock = $this->getMockBuilder(StatsTrait::class)
             ->setMethods(array_diff($availableFns, $mockFns))
             ->getMockForTrait();
+        $mock->method('getCommand')
+            ->willReturn('stats');
+
+        return $mock;
     }
 }

--- a/tests/Command/StatsTubeTest.php
+++ b/tests/Command/StatsTubeTest.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 class StatsTubeTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new StatsTube('test-tube'));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $tube = 'test-tube';
         static::assertEquals("stats-tube {$tube}", (new StatsTube($tube))->getCommand());
     }
 
-    public function testTubeIsValidated()
+    public function testTubeIsValidated(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Command/StatsTubeTest.php
+++ b/tests/Command/StatsTubeTest.php
@@ -14,7 +14,7 @@ class StatsTubeTest extends CommandTestCase
     public function testGetCommand()
     {
         $tube = 'test-tube';
-        static::assertEquals("stats-tube $tube", (new StatsTube($tube))->getCommand());
+        static::assertEquals("stats-tube {$tube}", (new StatsTube($tube))->getCommand());
     }
 
     public function testTubeIsValidated()

--- a/tests/Command/StatsTubeTest.php
+++ b/tests/Command/StatsTubeTest.php
@@ -16,7 +16,7 @@ class StatsTubeTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $tube = 'test-tube';
-        static::assertEquals("stats-tube {$tube}", (new StatsTube($tube))->getCommand());
+        static::assertSame("stats-tube {$tube}", (new StatsTube($tube))->getCommand());
     }
 
     public function testTubeIsValidated(): void

--- a/tests/Command/TouchTest.php
+++ b/tests/Command/TouchTest.php
@@ -17,7 +17,7 @@ class TouchTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $id = 234;
-        static::assertEquals("touch {$id}", (new Touch($id))->getCommand());
+        static::assertSame("touch {$id}", (new Touch($id))->getCommand());
     }
 
     public function testSuccessfulCommand(): void

--- a/tests/Command/TouchTest.php
+++ b/tests/Command/TouchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -7,18 +9,18 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class TouchTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Touch(123));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $id = 234;
         static::assertEquals("touch {$id}", (new Touch($id))->getCommand());
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $id = 123;
         $this->socket->expects(static::any())
@@ -29,7 +31,7 @@ class TouchTest extends CommandTestCase
         static::assertInstanceOf(Touch::class, $touch->process($this->socket));
     }
 
-    public function testErrorThrowsException()
+    public function testErrorThrowsException(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -39,7 +41,7 @@ class TouchTest extends CommandTestCase
         (new Touch(123))->process($this->socket);
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/TouchTest.php
+++ b/tests/Command/TouchTest.php
@@ -15,7 +15,7 @@ class TouchTest extends CommandTestCase
     public function testGetCommand()
     {
         $id = 234;
-        static::assertEquals("touch $id", (new Touch($id))->getCommand());
+        static::assertEquals("touch {$id}", (new Touch($id))->getCommand());
     }
 
     public function testSuccessfulCommand()
@@ -23,7 +23,7 @@ class TouchTest extends CommandTestCase
         $id = 123;
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturn("TOUCHED");
+            ->willReturn('TOUCHED');
 
         $touch = new Touch($id);
         static::assertInstanceOf(Touch::class, $touch->process($this->socket));

--- a/tests/Command/UseTubeTest.php
+++ b/tests/Command/UseTubeTest.php
@@ -15,7 +15,7 @@ class UseTubeTest extends CommandTestCase
     public function testGetCommand()
     {
         $tube = 'test-tube';
-        static::assertEquals("use $tube", (new UseTube($tube))->getCommand());
+        static::assertEquals("use {$tube}", (new UseTube($tube))->getCommand());
     }
 
     public function testTubeIsValidated()
@@ -30,7 +30,7 @@ class UseTubeTest extends CommandTestCase
         $tube = 'test-tube';
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturn("USING $tube");
+            ->willReturn("USING {$tube}");
 
         static::assertEquals($tube, (new UseTube($tube))->process($this->socket));
     }

--- a/tests/Command/UseTubeTest.php
+++ b/tests/Command/UseTubeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -7,25 +9,25 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 class UseTubeTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new UseTube('test-tube'));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $tube = 'test-tube';
         static::assertEquals("use {$tube}", (new UseTube($tube))->getCommand());
     }
 
-    public function testTubeIsValidated()
+    public function testTubeIsValidated(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new UseTube('');
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $tube = 'test-tube';
         $this->socket->expects(static::any())
@@ -35,7 +37,7 @@ class UseTubeTest extends CommandTestCase
         static::assertEquals($tube, (new UseTube($tube))->process($this->socket));
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/UseTubeTest.php
+++ b/tests/Command/UseTubeTest.php
@@ -17,7 +17,7 @@ class UseTubeTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $tube = 'test-tube';
-        static::assertEquals("use {$tube}", (new UseTube($tube))->getCommand());
+        static::assertSame("use {$tube}", (new UseTube($tube))->getCommand());
     }
 
     public function testTubeIsValidated(): void
@@ -34,7 +34,7 @@ class UseTubeTest extends CommandTestCase
             ->method('read')
             ->willReturn("USING {$tube}");
 
-        static::assertEquals($tube, (new UseTube($tube))->process($this->socket));
+        static::assertSame($tube, (new UseTube($tube))->process($this->socket));
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/Command/WatchTest.php
+++ b/tests/Command/WatchTest.php
@@ -15,7 +15,7 @@ class WatchTest extends CommandTestCase
     public function testGetCommand()
     {
         $tube = 'test-tube';
-        static::assertEquals("watch $tube", (new Watch($tube))->getCommand());
+        static::assertEquals("watch {$tube}", (new Watch($tube))->getCommand());
     }
 
     public function testTubeIsValidated()
@@ -31,7 +31,7 @@ class WatchTest extends CommandTestCase
         $watchingCount = 12;
         $this->socket->expects(static::any())
             ->method('read')
-            ->willReturn("WATCHING $watchingCount");
+            ->willReturn("WATCHING {$watchingCount}");
 
         static::assertEquals($watchingCount, (new Watch($tube))->process($this->socket));
     }

--- a/tests/Command/WatchTest.php
+++ b/tests/Command/WatchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
@@ -7,25 +9,25 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 class WatchTest extends CommandTestCase
 {
-    public function testImplementsCommand()
+    public function testImplementsCommand(): void
     {
         static::assertInstanceOf(CommandInterface::class, new Watch('test-tube'));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $tube = 'test-tube';
         static::assertEquals("watch {$tube}", (new Watch($tube))->getCommand());
     }
 
-    public function testTubeIsValidated()
+    public function testTubeIsValidated(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new Watch('');
     }
 
-    public function testSuccessfulCommand()
+    public function testSuccessfulCommand(): void
     {
         $tube = 'test-tube';
         $watchingCount = 12;
@@ -36,7 +38,7 @@ class WatchTest extends CommandTestCase
         static::assertEquals($watchingCount, (new Watch($tube))->process($this->socket));
     }
 
-    public function testUnknownStatusThrowsException()
+    public function testUnknownStatusThrowsException(): void
     {
         $this->expectException(CommandException::class);
 

--- a/tests/Command/WatchTest.php
+++ b/tests/Command/WatchTest.php
@@ -17,7 +17,7 @@ class WatchTest extends CommandTestCase
     public function testGetCommand(): void
     {
         $tube = 'test-tube';
-        static::assertEquals("watch {$tube}", (new Watch($tube))->getCommand());
+        static::assertSame("watch {$tube}", (new Watch($tube))->getCommand());
     }
 
     public function testTubeIsValidated(): void
@@ -35,7 +35,7 @@ class WatchTest extends CommandTestCase
             ->method('read')
             ->willReturn("WATCHING {$watchingCount}");
 
-        static::assertEquals($watchingCount, (new Watch($tube))->process($this->socket));
+        static::assertSame($watchingCount, (new Watch($tube))->process($this->socket));
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/Connection/SocketTest.php
+++ b/tests/Connection/SocketTest.php
@@ -54,8 +54,8 @@ class SocketTest extends TestCase
      */
     public function testConnectsWithTheCorrectDetails()
     {
-        $host    = 'someHost';
-        $port    = 145234;
+        $host = 'someHost';
+        $port = 145234;
         $timeout = 432;
 
         $fsockopen = $this->getFunctionMock(__NAMESPACE__, 'fsockopen');
@@ -71,7 +71,9 @@ class SocketTest extends TestCase
         $stream_set_timeout = $this->getFunctionMock(__NAMESPACE__, 'stream_set_timeout');
         $stream_set_timeout->expects(static::any())->willReturn(true);
 
-        (new Socket($host, $port, ['timeout' => $timeout]))->connect();
+        (new Socket($host, $port, [
+            'timeout' => $timeout,
+        ]))->connect();
     }
 
     public function testDisconnectWithValidConnection()
@@ -165,7 +167,6 @@ class SocketTest extends TestCase
     }
 
     /**
-     * @param array $mockFns
      * @return Socket|MockObject
      */
     protected function getMockSocket(array $mockFns)

--- a/tests/Connection/SocketTest.php
+++ b/tests/Connection/SocketTest.php
@@ -22,7 +22,7 @@ class SocketTest extends TestCase
     {
         $socket1 = new Socket('localhost', 11300);
         $socket2 = new Socket('localhost', 11301);
-        static::assertNotEquals($socket1->getUniqueIdentifier(), $socket2->getUniqueIdentifier());
+        static::assertNotSame($socket1->getUniqueIdentifier(), $socket2->getUniqueIdentifier());
     }
 
     public function testConnectOnSuccessReturnsSelf(): void
@@ -144,7 +144,7 @@ class SocketTest extends TestCase
         $expectedData = 'Some Data';
         $stream_get_line = $this->getFunctionMock(__NAMESPACE__, 'stream_get_line');
         $stream_get_line->expects(static::any())->willReturn($expectedData);
-        static::assertEquals($expectedData, $this->getMockSocket(['read'])->read());
+        static::assertSame($expectedData, $this->getMockSocket(['read'])->read());
     }
 
     public function testReadSuccessfullyWithLengthParam(): void
@@ -156,7 +156,7 @@ class SocketTest extends TestCase
         $fread = $this->getFunctionMock(__NAMESPACE__, 'fread');
         $fread->expects(static::any())->willReturn($expectedData);
 
-        static::assertEquals($expectedData, $this->getMockSocket(['read'])->read(9));
+        static::assertSame($expectedData, $this->getMockSocket(['read'])->read(9));
     }
 
     public function testReadFailsWithBadData(): void

--- a/tests/Connection/SocketTest.php
+++ b/tests/Connection/SocketTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Connection;
 
 use Phlib\Beanstalk\Exception\SocketException;
@@ -11,19 +13,19 @@ class SocketTest extends TestCase
 {
     use PHPMock;
 
-    public function testImplementsInterface()
+    public function testImplementsInterface(): void
     {
         static::assertInstanceOf(SocketInterface::class, new Socket('localhost'));
     }
 
-    public function testGetUniqueIdentifier()
+    public function testGetUniqueIdentifier(): void
     {
         $socket1 = new Socket('localhost', 11300);
         $socket2 = new Socket('localhost', 11301);
         static::assertNotEquals($socket1->getUniqueIdentifier(), $socket2->getUniqueIdentifier());
     }
 
-    public function testConnectOnSuccessReturnsSelf()
+    public function testConnectOnSuccessReturnsSelf(): void
     {
         $fsockopen = $this->getFunctionMock(__NAMESPACE__, 'fsockopen');
         $fsockopen->expects(static::any())->willReturn(true);
@@ -33,7 +35,7 @@ class SocketTest extends TestCase
         static::assertInstanceOf(Socket::class, (new Socket('host'))->connect());
     }
 
-    public function testConnectOnFailureThrowsError()
+    public function testConnectOnFailureThrowsError(): void
     {
         $this->expectException(SocketException::class);
 
@@ -52,7 +54,7 @@ class SocketTest extends TestCase
     /**
      * @doesNotPerformAssertions PHPMock assertions are not counted
      */
-    public function testConnectsWithTheCorrectDetails()
+    public function testConnectsWithTheCorrectDetails(): void
     {
         $host = 'someHost';
         $port = 145234;
@@ -76,7 +78,7 @@ class SocketTest extends TestCase
         ]))->connect();
     }
 
-    public function testDisconnectWithValidConnection()
+    public function testDisconnectWithValidConnection(): void
     {
         $fsockopen = $this->getFunctionMock(__NAMESPACE__, 'fsockopen');
         $fsockopen->expects(static::any())->willReturn(fopen('php://memory', 'r+'));
@@ -90,7 +92,7 @@ class SocketTest extends TestCase
         $socket->disconnect();
     }
 
-    public function testDisconnectWithNoConnection()
+    public function testDisconnectWithNoConnection(): void
     {
         $fsockopen = $this->getFunctionMock(__NAMESPACE__, 'fsockopen');
         $fsockopen->expects(static::any())->willReturn(true);
@@ -107,7 +109,7 @@ class SocketTest extends TestCase
     /**
      * @doesNotPerformAssertions PHPMock assertions are not counted
      */
-    public function testWriteSuccessfullyToTheConnection()
+    public function testWriteSuccessfullyToTheConnection(): void
     {
         $data = 'Some Data';
         $dataLength = 9 + strlen(Socket::EOL);
@@ -125,7 +127,7 @@ class SocketTest extends TestCase
             ->write($data);
     }
 
-    public function testWriteThrowsExceptionOnError()
+    public function testWriteThrowsExceptionOnError(): void
     {
         $this->expectException(SocketException::class);
 
@@ -137,7 +139,7 @@ class SocketTest extends TestCase
             ->write('Some Data');
     }
 
-    public function testReadSuccessfullyFromTheConnection()
+    public function testReadSuccessfullyFromTheConnection(): void
     {
         $expectedData = 'Some Data';
         $stream_get_line = $this->getFunctionMock(__NAMESPACE__, 'stream_get_line');
@@ -145,7 +147,7 @@ class SocketTest extends TestCase
         static::assertEquals($expectedData, $this->getMockSocket(['read'])->read());
     }
 
-    public function testReadSuccessfullyWithLengthParam()
+    public function testReadSuccessfullyWithLengthParam(): void
     {
         $expectedData = 'Some Data';
 
@@ -157,7 +159,7 @@ class SocketTest extends TestCase
         static::assertEquals($expectedData, $this->getMockSocket(['read'])->read(9));
     }
 
-    public function testReadFailsWithBadData()
+    public function testReadFailsWithBadData(): void
     {
         $this->expectException(SocketException::class);
 
@@ -169,7 +171,7 @@ class SocketTest extends TestCase
     /**
      * @return Socket|MockObject
      */
-    protected function getMockSocket(array $mockFns)
+    protected function getMockSocket(array $mockFns): Socket
     {
         $availableFns = ['connect', 'disconnect', 'read', 'write', 'getUniqueIdentifier'];
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -269,6 +269,6 @@ class ConnectionTest extends TestCase
                 ->method('read')
                 ->willReturn($response);
         }
-        return call_user_func_array([$this->beanstalk, $method], $arguments);
+        return $this->beanstalk->{$method}(...$arguments);
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -33,7 +33,7 @@ class ConnectionTest extends TestCase
 
     public function testSocketIsSetCorrectly(): void
     {
-        static::assertEquals($this->socket, $this->beanstalk->getSocket());
+        static::assertSame($this->socket, $this->beanstalk->getSocket());
     }
 
     public function testDefaultSocketImplementation(): void
@@ -84,7 +84,7 @@ class ConnectionTest extends TestCase
             ->method('read')
             ->willReturnOnConsecutiveCalls('RESERVED 123 456', "Array\r\n");
         $jobData = $this->beanstalk->reserve();
-        static::assertEquals($expectedData, $jobData['body']);
+        static::assertSame($expectedData, $jobData['body']);
     }
 
     public function testDelete(): void
@@ -207,18 +207,18 @@ class ConnectionTest extends TestCase
     {
         $bound = 1;
         $quantity = $this->execute("kick {$bound}", 'KICKED 0', 'kick', [$bound]);
-        static::assertEquals(0, $quantity);
+        static::assertSame(0, $quantity);
     }
 
     public function testDefaultListOfTubesWatched(): void
     {
         $expected = ['default'];
-        static::assertEquals($expected, $this->beanstalk->listTubesWatched());
+        static::assertSame($expected, $this->beanstalk->listTubesWatched());
     }
 
     public function testDefaultTubeUsed(): void
     {
-        static::assertEquals('default', $this->beanstalk->listTubeUsed());
+        static::assertSame('default', $this->beanstalk->listTubeUsed());
     }
 
     public function testStats(): void
@@ -229,7 +229,7 @@ class ConnectionTest extends TestCase
         ];
 
         $actual = $this->execute('stats', ["OK 1234\r\n", "---\n{$yaml}\r\n"], 'stats');
-        static::assertEquals($stats, $actual);
+        static::assertSame($stats, $actual);
     }
 
     public function testStatsJob(): void
@@ -240,7 +240,7 @@ class ConnectionTest extends TestCase
         ];
 
         $actual = $this->execute('stats-job', ["OK 1234\r\n", "---\n{$yaml}\r\n"], 'statsJob', [123]);
-        static::assertEquals($stats, $actual);
+        static::assertSame($stats, $actual);
     }
 
     public function testStatsTube(): void
@@ -251,7 +251,7 @@ class ConnectionTest extends TestCase
         ];
 
         $actual = $this->execute('stats-tube', ["OK 1234\r\n", "---\n{$yaml}\r\n"], 'statsTube', ['test-tube']);
-        static::assertEquals($stats, $actual);
+        static::assertSame($stats, $actual);
     }
 
     /**

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -76,7 +76,10 @@ class ConnectionTest extends TestCase
 
     public function testReserveDecodesData()
     {
-        $expectedData = ['foo' => 'bar' , 'bar' => 'baz'];
+        $expectedData = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ];
         $expectedData = @(string)$expectedData;
         $this->socket->expects(static::atLeastOnce())
             ->method('read')
@@ -88,43 +91,43 @@ class ConnectionTest extends TestCase
     public function testDelete()
     {
         $id = 234;
-        $this->execute("delete $id", 'DELETED', 'delete', [$id]);
+        $this->execute("delete {$id}", 'DELETED', 'delete', [$id]);
     }
 
     public function testRelease()
     {
         $id = 234;
-        $this->execute("release $id", 'RELEASED', 'release', [$id]);
+        $this->execute("release {$id}", 'RELEASED', 'release', [$id]);
     }
 
     public function testUseTube()
     {
         $tube = 'test-tube';
-        $this->execute("use $tube", 'USING', 'useTube', [$tube]);
+        $this->execute("use {$tube}", 'USING', 'useTube', [$tube]);
     }
 
     public function testBury()
     {
         $id = 534;
-        $this->execute("bury $id", 'BURIED', 'bury', [$id]);
+        $this->execute("bury {$id}", 'BURIED', 'bury', [$id]);
     }
 
     public function testTouch()
     {
         $id = 567;
-        $this->execute("touch $id", 'TOUCHED', 'touch', [$id]);
+        $this->execute("touch {$id}", 'TOUCHED', 'touch', [$id]);
     }
 
     public function testWatch()
     {
         $tube = 'test-tube';
-        $this->execute("watch $tube", "WATCHING $tube", 'watch', [$tube]);
+        $this->execute("watch {$tube}", "WATCHING {$tube}", 'watch', [$tube]);
     }
 
     public function testWatchForExistingWatchedTube()
     {
         $tube = 'test-tube';
-        $this->execute("watch $tube", "WATCHING 123", 'watch', [$tube]);
+        $this->execute("watch {$tube}", 'WATCHING 123', 'watch', [$tube]);
         $this->beanstalk->watch($tube);
     }
 
@@ -135,7 +138,7 @@ class ConnectionTest extends TestCase
             ->method('read')
             ->willReturn('WATCHING 123');
         $this->beanstalk->watch($tube);
-        $this->execute("ignore $tube", 'WATCHING 123', 'ignore', [$tube]);
+        $this->execute("ignore {$tube}", 'WATCHING 123', 'ignore', [$tube]);
     }
 
     public function testIgnoreDoesNothingWhenNotWatching()
@@ -154,22 +157,22 @@ class ConnectionTest extends TestCase
     public function testPeek()
     {
         $id = 245;
-        $this->execute("peek $id", ["FOUND $id 678", '{"foo":"bar","bar":"baz"}'], 'peek', [$id]);
+        $this->execute("peek {$id}", ["FOUND {$id} 678", '{"foo":"bar","bar":"baz"}'], 'peek', [$id]);
     }
 
     public function testPeekReady()
     {
-        $this->execute("peek-ready", ["FOUND 234 678", '{"foo":"bar","bar":"baz"}'], 'peekReady');
+        $this->execute('peek-ready', ['FOUND 234 678', '{"foo":"bar","bar":"baz"}'], 'peekReady');
     }
 
     public function testPeekDelayed()
     {
-        $this->execute("peek-delayed", ["FOUND 234 678", '{"foo":"bar","bar":"baz"}'], 'peekDelayed');
+        $this->execute('peek-delayed', ['FOUND 234 678', '{"foo":"bar","bar":"baz"}'], 'peekDelayed');
     }
 
     public function testPeekBuried()
     {
-        $this->execute("peek-buried", ["FOUND 234 678", '{"foo":"bar","bar":"baz"}'], 'peekBuried');
+        $this->execute('peek-buried', ['FOUND 234 678', '{"foo":"bar","bar":"baz"}'], 'peekBuried');
     }
 
     public function testPeekNotFound()
@@ -177,34 +180,34 @@ class ConnectionTest extends TestCase
         $this->expectException(NotFoundException::class);
 
         $id = 245;
-        static::assertFalse($this->execute("peek $id", 'NOT_FOUND', 'peek', [$id]));
+        static::assertFalse($this->execute("peek {$id}", 'NOT_FOUND', 'peek', [$id]));
     }
 
     public function testPeekReadyNotFound()
     {
-        static::assertFalse($this->execute("peek-ready", 'NOT_FOUND', 'peekReady'));
+        static::assertFalse($this->execute('peek-ready', 'NOT_FOUND', 'peekReady'));
     }
 
     public function testPeekDelayedNotFound()
     {
-        static::assertFalse($this->execute("peek-delayed", 'NOT_FOUND', 'peekDelayed'));
+        static::assertFalse($this->execute('peek-delayed', 'NOT_FOUND', 'peekDelayed'));
     }
 
     public function testPeekBuriedNotFound()
     {
-        static::assertFalse($this->execute("peek-buried", 'NOT_FOUND', 'peekBuried'));
+        static::assertFalse($this->execute('peek-buried', 'NOT_FOUND', 'peekBuried'));
     }
 
     public function testKick()
     {
         $bound = 123;
-        $this->execute("kick $bound", "KICKED $bound", 'kick', [$bound]);
+        $this->execute("kick {$bound}", "KICKED {$bound}", 'kick', [$bound]);
     }
 
     public function testKickEmpty()
     {
         $bound = 1;
-        $quantity = $this->execute("kick $bound", "KICKED 0", 'kick', [$bound]);
+        $quantity = $this->execute("kick {$bound}", 'KICKED 0', 'kick', [$bound]);
         static::assertEquals(0, $quantity);
     }
 
@@ -221,28 +224,34 @@ class ConnectionTest extends TestCase
 
     public function testStats()
     {
-        $yaml  = 'key1: value1';
-        $stats = ['key1' => 'value1'];
+        $yaml = 'key1: value1';
+        $stats = [
+            'key1' => 'value1',
+        ];
 
-        $actual = $this->execute('stats', ["OK 1234\r\n", "---\n$yaml\r\n"], 'stats');
+        $actual = $this->execute('stats', ["OK 1234\r\n", "---\n{$yaml}\r\n"], 'stats');
         static::assertEquals($stats, $actual);
     }
 
     public function testStatsJob()
     {
-        $yaml  = 'key1: value1';
-        $stats = ['key1' => 'value1'];
+        $yaml = 'key1: value1';
+        $stats = [
+            'key1' => 'value1',
+        ];
 
-        $actual = $this->execute('stats-job', ["OK 1234\r\n", "---\n$yaml\r\n"], 'statsJob', [123]);
+        $actual = $this->execute('stats-job', ["OK 1234\r\n", "---\n{$yaml}\r\n"], 'statsJob', [123]);
         static::assertEquals($stats, $actual);
     }
 
     public function testStatsTube()
     {
-        $yaml  = 'key1: value1';
-        $stats = ['key1' => 'value1'];
+        $yaml = 'key1: value1';
+        $stats = [
+            'key1' => 'value1',
+        ];
 
-        $actual = $this->execute('stats-tube', ["OK 1234\r\n", "---\n$yaml\r\n"], 'statsTube', ['test-tube']);
+        $actual = $this->execute('stats-tube', ["OK 1234\r\n", "---\n{$yaml}\r\n"], 'statsTube', ['test-tube']);
         static::assertEquals($stats, $actual);
     }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -13,36 +15,33 @@ class ConnectionTest extends TestCase
     /**
      * @var Socket|MockObject
      */
-    protected $socket;
+    protected MockObject $socket;
 
-    /**
-     * @var Connection
-     */
-    protected $beanstalk;
+    protected Connection $beanstalk;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->socket = $this->createMock(Socket::class);
         $this->beanstalk = new Connection($this->socket);
         parent::setUp();
     }
 
-    public function testImplementsInterface()
+    public function testImplementsInterface(): void
     {
         static::assertInstanceOf(ConnectionInterface::class, $this->beanstalk);
     }
 
-    public function testSocketIsSetCorrectly()
+    public function testSocketIsSetCorrectly(): void
     {
         static::assertEquals($this->socket, $this->beanstalk->getSocket());
     }
 
-    public function testDefaultSocketImplementation()
+    public function testDefaultSocketImplementation(): void
     {
         static::assertInstanceOf(Socket::class, $this->beanstalk->getSocket());
     }
 
-    public function testDisconnectCallsSocket()
+    public function testDisconnectCallsSocket(): void
     {
         $this->socket->expects(static::once())
             ->method('disconnect')
@@ -50,7 +49,7 @@ class ConnectionTest extends TestCase
         $this->beanstalk->disconnect();
     }
 
-    public function testDisconnectReturnsValue()
+    public function testDisconnectReturnsValue(): void
     {
         $this->socket->expects(static::any())
             ->method('disconnect')
@@ -58,7 +57,7 @@ class ConnectionTest extends TestCase
         static::assertTrue($this->beanstalk->disconnect());
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $this->socket->expects(static::atLeastOnce())
             ->method('read')
@@ -66,7 +65,7 @@ class ConnectionTest extends TestCase
         $this->beanstalk->put('foo-bar');
     }
 
-    public function testReserve()
+    public function testReserve(): void
     {
         $this->socket->expects(static::atLeastOnce())
             ->method('read')
@@ -74,7 +73,7 @@ class ConnectionTest extends TestCase
         $this->beanstalk->reserve();
     }
 
-    public function testReserveDecodesData()
+    public function testReserveDecodesData(): void
     {
         $expectedData = [
             'foo' => 'bar',
@@ -88,50 +87,50 @@ class ConnectionTest extends TestCase
         static::assertEquals($expectedData, $jobData['body']);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $id = 234;
         $this->execute("delete {$id}", 'DELETED', 'delete', [$id]);
     }
 
-    public function testRelease()
+    public function testRelease(): void
     {
         $id = 234;
         $this->execute("release {$id}", 'RELEASED', 'release', [$id]);
     }
 
-    public function testUseTube()
+    public function testUseTube(): void
     {
         $tube = 'test-tube';
-        $this->execute("use {$tube}", 'USING', 'useTube', [$tube]);
+        $this->execute("use {$tube}", "USING {$tube}", 'useTube', [$tube]);
     }
 
-    public function testBury()
+    public function testBury(): void
     {
         $id = 534;
         $this->execute("bury {$id}", 'BURIED', 'bury', [$id]);
     }
 
-    public function testTouch()
+    public function testTouch(): void
     {
         $id = 567;
         $this->execute("touch {$id}", 'TOUCHED', 'touch', [$id]);
     }
 
-    public function testWatch()
+    public function testWatch(): void
     {
         $tube = 'test-tube';
         $this->execute("watch {$tube}", "WATCHING {$tube}", 'watch', [$tube]);
     }
 
-    public function testWatchForExistingWatchedTube()
+    public function testWatchForExistingWatchedTube(): void
     {
         $tube = 'test-tube';
         $this->execute("watch {$tube}", 'WATCHING 123', 'watch', [$tube]);
         $this->beanstalk->watch($tube);
     }
 
-    public function testIgnore()
+    public function testIgnore(): void
     {
         $tube = 'test-tube';
         $this->socket->expects(static::any())
@@ -141,7 +140,7 @@ class ConnectionTest extends TestCase
         $this->execute("ignore {$tube}", 'WATCHING 123', 'ignore', [$tube]);
     }
 
-    public function testIgnoreDoesNothingWhenNotWatching()
+    public function testIgnoreDoesNothingWhenNotWatching(): void
     {
         $tube = 'test-tube';
         $this->socket->expects(static::never())
@@ -149,33 +148,33 @@ class ConnectionTest extends TestCase
         $this->beanstalk->ignore($tube);
     }
 
-    public function testIgnoreDoesNothingWhenOnlyHasOneTube()
+    public function testIgnoreDoesNothingWhenOnlyHasOneTube(): void
     {
         static::assertFalse($this->beanstalk->ignore('default'));
     }
 
-    public function testPeek()
+    public function testPeek(): void
     {
         $id = 245;
         $this->execute("peek {$id}", ["FOUND {$id} 678", '{"foo":"bar","bar":"baz"}'], 'peek', [$id]);
     }
 
-    public function testPeekReady()
+    public function testPeekReady(): void
     {
         $this->execute('peek-ready', ['FOUND 234 678', '{"foo":"bar","bar":"baz"}'], 'peekReady');
     }
 
-    public function testPeekDelayed()
+    public function testPeekDelayed(): void
     {
         $this->execute('peek-delayed', ['FOUND 234 678', '{"foo":"bar","bar":"baz"}'], 'peekDelayed');
     }
 
-    public function testPeekBuried()
+    public function testPeekBuried(): void
     {
         $this->execute('peek-buried', ['FOUND 234 678', '{"foo":"bar","bar":"baz"}'], 'peekBuried');
     }
 
-    public function testPeekNotFound()
+    public function testPeekNotFound(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -183,46 +182,46 @@ class ConnectionTest extends TestCase
         static::assertFalse($this->execute("peek {$id}", 'NOT_FOUND', 'peek', [$id]));
     }
 
-    public function testPeekReadyNotFound()
+    public function testPeekReadyNotFound(): void
     {
         static::assertFalse($this->execute('peek-ready', 'NOT_FOUND', 'peekReady'));
     }
 
-    public function testPeekDelayedNotFound()
+    public function testPeekDelayedNotFound(): void
     {
         static::assertFalse($this->execute('peek-delayed', 'NOT_FOUND', 'peekDelayed'));
     }
 
-    public function testPeekBuriedNotFound()
+    public function testPeekBuriedNotFound(): void
     {
         static::assertFalse($this->execute('peek-buried', 'NOT_FOUND', 'peekBuried'));
     }
 
-    public function testKick()
+    public function testKick(): void
     {
         $bound = 123;
         $this->execute("kick {$bound}", "KICKED {$bound}", 'kick', [$bound]);
     }
 
-    public function testKickEmpty()
+    public function testKickEmpty(): void
     {
         $bound = 1;
         $quantity = $this->execute("kick {$bound}", 'KICKED 0', 'kick', [$bound]);
         static::assertEquals(0, $quantity);
     }
 
-    public function testDefaultListOfTubesWatched()
+    public function testDefaultListOfTubesWatched(): void
     {
         $expected = ['default'];
         static::assertEquals($expected, $this->beanstalk->listTubesWatched());
     }
 
-    public function testDefaultTubeUsed()
+    public function testDefaultTubeUsed(): void
     {
         static::assertEquals('default', $this->beanstalk->listTubeUsed());
     }
 
-    public function testStats()
+    public function testStats(): void
     {
         $yaml = 'key1: value1';
         $stats = [
@@ -233,7 +232,7 @@ class ConnectionTest extends TestCase
         static::assertEquals($stats, $actual);
     }
 
-    public function testStatsJob()
+    public function testStatsJob(): void
     {
         $yaml = 'key1: value1';
         $stats = [
@@ -244,7 +243,7 @@ class ConnectionTest extends TestCase
         static::assertEquals($stats, $actual);
     }
 
-    public function testStatsTube()
+    public function testStatsTube(): void
     {
         $yaml = 'key1: value1';
         $stats = [
@@ -255,7 +254,11 @@ class ConnectionTest extends TestCase
         static::assertEquals($stats, $actual);
     }
 
-    protected function execute($command, $response, $method, array $arguments = [])
+    /**
+     * @param mixed $response
+     * @return mixed
+     */
+    protected function execute(string $command, $response, string $method, array $arguments = [])
     {
         $this->socket->expects(static::once())
             ->method('write')

--- a/tests/Console/ServerStatsCommandTest.php
+++ b/tests/Console/ServerStatsCommandTest.php
@@ -107,19 +107,19 @@ class ServerStatsCommandTest extends ConsoleTestCase
 
         // Headers
         static::assertStringContainsString(
-            "Host: " . self::STATS_INFO['hostname'] . " (pid " . self::STATS_INFO['pid'] . ")",
+            'Host: ' . self::STATS_INFO['hostname'] . ' (pid ' . self::STATS_INFO['pid'] . ')',
             $output
         );
         static::assertStringContainsString(
-            "Beanstalk Version: " . self::STATS_INFO['version'],
+            'Beanstalk Version: ' . self::STATS_INFO['version'],
             $output
         );
         static::assertStringContainsString(
-            "Resources: uptime/" . self::STATS_INFO['uptime'] . ", connections/" . self::STATS_INFO['total-connections'],
+            'Resources: uptime/' . self::STATS_INFO['uptime'] . ', connections/' . self::STATS_INFO['total-connections'],
             $output
         );
         static::assertStringContainsString(
-            "Jobs: total/" . self::STATS_INFO['total-jobs'] . ", timeouts/" . self::STATS_INFO['job-timeouts'],
+            'Jobs: total/' . self::STATS_INFO['total-jobs'] . ', timeouts/' . self::STATS_INFO['job-timeouts'],
             $output
         );
 

--- a/tests/Console/ServerTubesCommandTest.php
+++ b/tests/Console/ServerTubesCommandTest.php
@@ -35,7 +35,7 @@ class ServerTubesCommandTest extends ConsoleTestCase
             'current-watching' => 81,
             'current-waiting' => 6,
             'cmd-delete' => 3636434,
-        ]
+        ],
     ];
 
     /**

--- a/tests/Console/TubePeekCommandTest.php
+++ b/tests/Console/TubePeekCommandTest.php
@@ -65,7 +65,7 @@ class TubePeekCommandTest extends ConsoleTestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             'tube' => $tube,
-            '--status' => 'buried'
+            '--status' => 'buried',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -94,7 +94,7 @@ class TubePeekCommandTest extends ConsoleTestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             'tube' => $tube,
-            '--status' => 'delayed'
+            '--status' => 'delayed',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -123,7 +123,7 @@ class TubePeekCommandTest extends ConsoleTestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             'tube' => $tube,
-            '--status' => 'ready'
+            '--status' => 'ready',
         ]);
 
         $output = $this->commandTester->getDisplay();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         static::assertInstanceOf(ConnectionInterface::class, Factory::create('localhost'));
     }
@@ -18,12 +20,12 @@ class FactoryTest extends TestCase
     /**
      * @dataProvider createFromArrayDataProvider
      */
-    public function testCreateFromArray($expectedClass, $config)
+    public function testCreateFromArray($expectedClass, $config): void
     {
         static::assertInstanceOf(ConnectionInterface::class, Factory::create('localhost'));
     }
 
-    public function createFromArrayDataProvider()
+    public function createFromArrayDataProvider(): array
     {
         $connectionClass = Connection::class;
         $poolClass = Pool::class;
@@ -59,10 +61,9 @@ class FactoryTest extends TestCase
     }
 
     /**
-     * @param string $strategyClass
      * @dataProvider creatingPoolUsesStrategyDataProvider
      */
-    public function testCreatingPoolUsesStrategy($strategyClass)
+    public function testCreatingPoolUsesStrategy(string $strategyClass): void
     {
         $hostConfig = [
             'host' => 'localhost',
@@ -80,7 +81,7 @@ class FactoryTest extends TestCase
         static::assertInstanceOf($strategyClass, $collection->getSelectionStrategy());
     }
 
-    public function creatingPoolUsesStrategyDataProvider()
+    public function creatingPoolUsesStrategyDataProvider(): array
     {
         return [
             [RoundRobinStrategy::class],
@@ -88,7 +89,7 @@ class FactoryTest extends TestCase
         ];
     }
 
-    public function testCreatingPoolFailsWithInvalidStrategyClass()
+    public function testCreatingPoolFailsWithInvalidStrategyClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -102,14 +103,14 @@ class FactoryTest extends TestCase
         Factory::createFromArray($poolConfig);
     }
 
-    public function testCreateFromArrayFailsWhenEmpty()
+    public function testCreateFromArrayFailsWhenEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         Factory::createFromArray([]);
     }
 
-    public function testCreateConnections()
+    public function testCreateConnections(): void
     {
         $result = true;
         $config = [

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -26,14 +26,35 @@ class FactoryTest extends TestCase
     public function createFromArrayDataProvider()
     {
         $connectionClass = Connection::class;
-        $poolClass       = Pool::class;
-        $defaultHost     = ['host' => 'localhost'];
+        $poolClass = Pool::class;
+        $defaultHost = [
+            'host' => 'localhost',
+        ];
 
         return [
-            [$connectionClass, $defaultHost],
-            [$connectionClass, ['host' => 'localhost', 'port' => 123456]],
-            [$connectionClass, ['server' => $defaultHost]],
-            [$poolClass, ['servers' => [$defaultHost, $defaultHost]]]
+            [
+                $connectionClass,
+                $defaultHost,
+            ],
+            [
+                $connectionClass,
+                [
+                    'host' => 'localhost',
+                    'port' => 123456,
+                ],
+            ],
+            [
+                $connectionClass,
+                [
+                    'server' => $defaultHost,
+                ],
+            ],
+            [
+                $poolClass,
+                [
+                    'servers' => [$defaultHost, $defaultHost],
+                ],
+            ],
         ];
     }
 
@@ -43,10 +64,12 @@ class FactoryTest extends TestCase
      */
     public function testCreatingPoolUsesStrategy($strategyClass)
     {
-        $hostConfig = ['host' => 'localhost'];
+        $hostConfig = [
+            'host' => 'localhost',
+        ];
         $poolConfig = [
             'servers' => [$hostConfig, $hostConfig],
-            'strategyClass' => $strategyClass
+            'strategyClass' => $strategyClass,
         ];
         $pool = Factory::createFromArray($poolConfig);
         /* @var $pool Pool */
@@ -61,7 +84,7 @@ class FactoryTest extends TestCase
     {
         return [
             [RoundRobinStrategy::class],
-            [RandomStrategy::class]
+            [RandomStrategy::class],
         ];
     }
 
@@ -69,10 +92,12 @@ class FactoryTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $hostConfig = ['host' => 'localhost'];
+        $hostConfig = [
+            'host' => 'localhost',
+        ];
         $poolConfig = [
             'servers' => [$hostConfig, $hostConfig],
-            'strategyClass' => '\Some\RandomClass\ThatDoesnt\Exist'
+            'strategyClass' => '\Some\RandomClass\ThatDoesnt\Exist',
         ];
         Factory::createFromArray($poolConfig);
     }
@@ -87,7 +112,9 @@ class FactoryTest extends TestCase
     public function testCreateConnections()
     {
         $result = true;
-        $config = ['host' => 'locahost'];
+        $config = [
+            'host' => 'locahost',
+        ];
 
         $connections = Factory::createConnections([$config, $config, $config]);
         foreach ($connections as $connection) {

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -2,8 +2,8 @@
 
 namespace Phlib\Beanstalk;
 
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Connection\Socket;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,7 +25,7 @@ class IntegrationPoolTest extends TestCase
 
         $connections = [
             new Connection(new Socket(getenv('BSTALK1_HOST'), getenv('BSTALK1_PORT'))),
-            new Connection(new Socket(getenv('BSTALK2_HOST'), getenv('BSTALK2_PORT')))
+            new Connection(new Socket(getenv('BSTALK2_HOST'), getenv('BSTALK2_PORT'))),
         ];
         $this->beanstalk = new Pool(new Pool\Collection($connections));
     }

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\Socket;
@@ -11,12 +13,9 @@ use PHPUnit\Framework\TestCase;
  */
 class IntegrationPoolTest extends TestCase
 {
-    /**
-     * @var Connection
-     */
-    protected $beanstalk;
+    protected Pool $beanstalk;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (getenv('BSTALK_ENABLED') != true) {
             static::markTestSkipped();
@@ -24,13 +23,13 @@ class IntegrationPoolTest extends TestCase
         }
 
         $connections = [
-            new Connection(new Socket(getenv('BSTALK1_HOST'), getenv('BSTALK1_PORT'))),
-            new Connection(new Socket(getenv('BSTALK2_HOST'), getenv('BSTALK2_PORT'))),
+            new Connection(new Socket(getenv('BSTALK1_HOST'), (int)getenv('BSTALK1_PORT'))),
+            new Connection(new Socket(getenv('BSTALK2_HOST'), (int)getenv('BSTALK2_PORT'))),
         ];
         $this->beanstalk = new Pool(new Pool\Collection($connections));
     }
 
-    public function testReconnectingAfterDisconnect()
+    public function testReconnectingAfterDisconnect(): void
     {
         $this->beanstalk->listTubes(); // make sure we connect
         $this->beanstalk->disconnect();
@@ -40,38 +39,38 @@ class IntegrationPoolTest extends TestCase
         static::assertContains($tube, $this->beanstalk->listTubes());
     }
 
-    public function testStartWithDefaultTube()
+    public function testStartWithDefaultTube(): void
     {
         static::assertEquals('default', $this->beanstalk->listTubeUsed());
     }
 
-    public function testSwitchingUsedTube()
+    public function testSwitchingUsedTube(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->useTube($tube);
         static::assertEquals($tube, $this->beanstalk->listTubeUsed());
     }
 
-    public function testStartWithDefaultWatching()
+    public function testStartWithDefaultWatching(): void
     {
         static::assertEquals(['default'], $this->beanstalk->listTubesWatched());
     }
 
-    public function testWatchingMoreTubes()
+    public function testWatchingMoreTubes(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->watch($tube);
         static::assertContains($tube, $this->beanstalk->listTubesWatched());
     }
 
-    public function testListTubes()
+    public function testListTubes(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->useTube($tube);
         static::assertContains($tube, $this->beanstalk->listTubes());
     }
 
-    public function testFullJobProcess()
+    public function testFullJobProcess(): void
     {
         $this->setupTube('integration-test');
         // make sure it's empty
@@ -90,7 +89,7 @@ class IntegrationPoolTest extends TestCase
         static::assertFalse($this->beanstalk->peekReady());
     }
 
-    public function testBuriedJobProcess()
+    public function testBuriedJobProcess(): void
     {
         $this->setupTube('integration-test');
         try {
@@ -115,7 +114,7 @@ class IntegrationPoolTest extends TestCase
         $this->beanstalk->delete($buriedData['id']);
     }
 
-    public function testLargeJobData()
+    public function testLargeJobData(): void
     {
         $this->setupTube('integration-test');
 
@@ -128,7 +127,7 @@ class IntegrationPoolTest extends TestCase
         static::assertEquals($length, strlen($jobData['body']));
     }
 
-    public function setupTube($tube)
+    public function setupTube($tube): void
     {
         $this->beanstalk
             ->useTube($tube)

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -17,7 +17,7 @@ class IntegrationPoolTest extends TestCase
 
     protected function setUp(): void
     {
-        if (getenv('BSTALK_ENABLED') != true) {
+        if ((bool)getenv('BSTALK_ENABLED') !== true) {
             static::markTestSkipped();
             return;
         }
@@ -41,19 +41,19 @@ class IntegrationPoolTest extends TestCase
 
     public function testStartWithDefaultTube(): void
     {
-        static::assertEquals('default', $this->beanstalk->listTubeUsed());
+        static::assertSame('default', $this->beanstalk->listTubeUsed());
     }
 
     public function testSwitchingUsedTube(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->useTube($tube);
-        static::assertEquals($tube, $this->beanstalk->listTubeUsed());
+        static::assertSame($tube, $this->beanstalk->listTubeUsed());
     }
 
     public function testStartWithDefaultWatching(): void
     {
-        static::assertEquals(['default'], $this->beanstalk->listTubesWatched());
+        static::assertSame(['default'], $this->beanstalk->listTubesWatched());
     }
 
     public function testWatchingMoreTubes(): void
@@ -80,8 +80,8 @@ class IntegrationPoolTest extends TestCase
         $id = $this->beanstalk->put($data);
         $jobData = $this->beanstalk->reserve();
 
-        static::assertEquals($id, $jobData['id']);
-        static::assertEquals($data, $jobData['body']);
+        static::assertSame($id, $jobData['id']);
+        static::assertSame($data, $jobData['body']);
 
         $this->beanstalk->touch($jobData['id']);
         $this->beanstalk->delete($jobData['id']);
@@ -102,13 +102,13 @@ class IntegrationPoolTest extends TestCase
         $id = $this->beanstalk->put($data);
         $jobData = $this->beanstalk->reserve();
 
-        static::assertEquals($id, $jobData['id']);
-        static::assertEquals($data, $jobData['body']);
+        static::assertSame($id, $jobData['id']);
+        static::assertSame($data, $jobData['body']);
 
         $this->beanstalk->bury($jobData['id']);
 
         $buriedData = $this->beanstalk->peekBuried();
-        static::assertEquals($jobData['id'], $buriedData['id']);
+        static::assertSame($jobData['id'], $buriedData['id']);
 
         $this->beanstalk->kick(1);
         $this->beanstalk->delete($buriedData['id']);
@@ -124,7 +124,7 @@ class IntegrationPoolTest extends TestCase
         $jobData = $this->beanstalk->reserve();
         $this->beanstalk->delete($jobData['id']);
 
-        static::assertEquals($length, strlen($jobData['body']));
+        static::assertSame($length, strlen($jobData['body']));
     }
 
     public function setupTube($tube): void

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -2,8 +2,8 @@
 
 namespace Phlib\Beanstalk;
 
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Connection\Socket;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\Socket;
@@ -11,22 +13,19 @@ use PHPUnit\Framework\TestCase;
  */
 class IntegrationTest extends TestCase
 {
-    /**
-     * @var Connection
-     */
-    protected $beanstalk;
+    protected Connection $beanstalk;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (getenv('BSTALK_ENABLED') != true) {
             static::markTestSkipped();
             return;
         }
 
-        $this->beanstalk = new Connection(new Socket(getenv('BSTALK1_HOST'), getenv('BSTALK1_PORT')));
+        $this->beanstalk = new Connection(new Socket(getenv('BSTALK1_HOST'), (int)getenv('BSTALK1_PORT')));
     }
 
-    public function testReconnectingAfterDisconnect()
+    public function testReconnectingAfterDisconnect(): void
     {
         $this->beanstalk->listTubes(); // make sure we connect
         $this->beanstalk->disconnect();
@@ -36,38 +35,38 @@ class IntegrationTest extends TestCase
         static::assertContains($tube, $this->beanstalk->listTubes());
     }
 
-    public function testStartWithDefaultTube()
+    public function testStartWithDefaultTube(): void
     {
         static::assertEquals('default', $this->beanstalk->listTubeUsed());
     }
 
-    public function testSwitchingUsedTube()
+    public function testSwitchingUsedTube(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->useTube($tube);
         static::assertEquals($tube, $this->beanstalk->listTubeUsed());
     }
 
-    public function testStartWithDefaultWatching()
+    public function testStartWithDefaultWatching(): void
     {
         static::assertEquals(['default'], $this->beanstalk->listTubesWatched());
     }
 
-    public function testWatchingMoreTubes()
+    public function testWatchingMoreTubes(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->watch($tube);
         static::assertContains($tube, $this->beanstalk->listTubesWatched());
     }
 
-    public function testListTubes()
+    public function testListTubes(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->useTube($tube);
         static::assertContains($tube, $this->beanstalk->listTubes());
     }
 
-    public function testFullJobProcess()
+    public function testFullJobProcess(): void
     {
         $this->setupTube('integration-test');
         // make sure it's empty
@@ -86,7 +85,7 @@ class IntegrationTest extends TestCase
         static::assertFalse($this->beanstalk->peekReady());
     }
 
-    public function testBuriedJobProcess()
+    public function testBuriedJobProcess(): void
     {
         $this->setupTube('integration-test');
         try {
@@ -111,7 +110,7 @@ class IntegrationTest extends TestCase
         $this->beanstalk->delete($buriedData['id']);
     }
 
-    public function testLargeJobData()
+    public function testLargeJobData(): void
     {
         $this->setupTube('integration-test');
 
@@ -124,7 +123,7 @@ class IntegrationTest extends TestCase
         static::assertEquals($length, strlen($jobData['body']));
     }
 
-    public function setupTube($tube)
+    public function setupTube($tube): void
     {
         $this->beanstalk
             ->useTube($tube)

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -17,7 +17,7 @@ class IntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        if (getenv('BSTALK_ENABLED') != true) {
+        if ((bool)getenv('BSTALK_ENABLED') !== true) {
             static::markTestSkipped();
             return;
         }
@@ -37,19 +37,19 @@ class IntegrationTest extends TestCase
 
     public function testStartWithDefaultTube(): void
     {
-        static::assertEquals('default', $this->beanstalk->listTubeUsed());
+        static::assertSame('default', $this->beanstalk->listTubeUsed());
     }
 
     public function testSwitchingUsedTube(): void
     {
         $tube = 'test-tube';
         $this->beanstalk->useTube($tube);
-        static::assertEquals($tube, $this->beanstalk->listTubeUsed());
+        static::assertSame($tube, $this->beanstalk->listTubeUsed());
     }
 
     public function testStartWithDefaultWatching(): void
     {
-        static::assertEquals(['default'], $this->beanstalk->listTubesWatched());
+        static::assertSame(['default'], $this->beanstalk->listTubesWatched());
     }
 
     public function testWatchingMoreTubes(): void
@@ -76,8 +76,8 @@ class IntegrationTest extends TestCase
         $id = $this->beanstalk->put($data);
         $jobData = $this->beanstalk->reserve();
 
-        static::assertEquals($id, $jobData['id']);
-        static::assertEquals($data, $jobData['body']);
+        static::assertSame($id, $jobData['id']);
+        static::assertSame($data, $jobData['body']);
 
         $this->beanstalk->touch($jobData['id']);
         $this->beanstalk->delete($jobData['id']);
@@ -98,13 +98,13 @@ class IntegrationTest extends TestCase
         $id = $this->beanstalk->put($data);
         $jobData = $this->beanstalk->reserve();
 
-        static::assertEquals($id, $jobData['id']);
-        static::assertEquals($data, $jobData['body']);
+        static::assertSame($id, $jobData['id']);
+        static::assertSame($data, $jobData['body']);
 
         $this->beanstalk->bury($jobData['id']);
 
         $buriedData = $this->beanstalk->peekBuried();
-        static::assertEquals($jobData['id'], $buriedData['id']);
+        static::assertSame($jobData['id'], $buriedData['id']);
 
         $this->beanstalk->kick(1);
         $this->beanstalk->delete($buriedData['id']);
@@ -120,7 +120,7 @@ class IntegrationTest extends TestCase
         $jobData = $this->beanstalk->reserve();
         $this->beanstalk->delete($jobData['id']);
 
-        static::assertEquals($length, strlen($jobData['body']));
+        static::assertSame($length, strlen($jobData['body']));
     }
 
     public function setupTube($tube): void

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Connection;
@@ -38,29 +40,24 @@ class CollectionTest extends TestCase
     /**
      * @var SelectionStrategyInterface|MockObject
      */
-    protected $strategy;
+    protected MockObject $strategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->strategy = $this->createMock(SelectionStrategyInterface::class);
     }
 
-    protected function tearDown()
-    {
-        $this->strategy = null;
-    }
-
-    public function testImplementsCollectionInterface()
+    public function testImplementsCollectionInterface(): void
     {
         static::assertInstanceOf(CollectionInterface::class, new Collection([], $this->strategy));
     }
 
-    public function testImplementsArrayAggregateInterface()
+    public function testImplementsArrayAggregateInterface(): void
     {
         static::assertInstanceOf(\IteratorAggregate::class, new Collection([], $this->strategy));
     }
 
-    public function testArrayAggregateReturnsConnections()
+    public function testArrayAggregateReturnsConnections(): void
     {
         $result = true;
         $collection = new Collection([$this->getMockConnection('id-123'), $this->getMockConnection('id-456')]);
@@ -70,7 +67,7 @@ class CollectionTest extends TestCase
         static::assertTrue($result);
     }
 
-    public function testArrayAggregateReturnsAllConnections()
+    public function testArrayAggregateReturnsAllConnections(): void
     {
         $count = 0;
         $collection = new Collection([$this->getMockConnection('id-123'), $this->getMockConnection('id-456')]);
@@ -136,19 +133,19 @@ class CollectionTest extends TestCase
         static::assertSame($expected, $collection->getAvailableKeys());
     }
 
-    public function testDefaultStrategyIsRoundRobin()
+    public function testDefaultStrategyIsRoundRobin(): void
     {
         $collection = new Collection([]);
         static::assertInstanceOf(RoundRobinStrategy::class, $collection->getSelectionStrategy());
     }
 
-    public function testConstructorCanSetTheStrategy()
+    public function testConstructorCanSetTheStrategy(): void
     {
         $collection = new Collection([], $this->strategy);
         static::assertSame($this->strategy, $collection->getSelectionStrategy());
     }
 
-    public function testConstructorTakesListOfValidConnections()
+    public function testConstructorTakesListOfValidConnections(): void
     {
         $serverKey = 'my-unique-key';
         $connection = $this->getMockConnection($serverKey);
@@ -156,14 +153,14 @@ class CollectionTest extends TestCase
         static::assertSame($connection, $collection->getConnection($serverKey));
     }
 
-    public function testConstructorChecksForValidConnections()
+    public function testConstructorChecksForValidConnections(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new Collection(['sdfdsf']);
     }
 
-    public function testForUnknownConnection()
+    public function testForUnknownConnection(): void
     {
         $this->expectException(NotFoundException::class);
 
@@ -171,7 +168,7 @@ class CollectionTest extends TestCase
         $collection->getConnection('foo-bar');
     }
 
-    public function testCanSendToExactConnection()
+    public function testCanSendToExactConnection(): void
     {
         $identifier = 'id-123';
         $command = 'stats';
@@ -185,7 +182,7 @@ class CollectionTest extends TestCase
         $collection->sendToExact($identifier, $command);
     }
 
-    public function testSendToExactOnError()
+    public function testSendToExactOnError(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -259,7 +256,7 @@ class CollectionTest extends TestCase
         $connection = new \ReflectionClass(Connection::class);
         foreach ($connection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             $methodName = $method->getName();
-            if (in_array($methodName, self::SEND_COMMANDS_ALLOWED)) {
+            if (array_key_exists($methodName, self::SEND_COMMANDS_ALLOWED)) {
                 continue;
             }
             if ($methodName === '__construct') {
@@ -269,7 +266,7 @@ class CollectionTest extends TestCase
         }
     }
 
-    public function testGetConnectionThatHasErrored()
+    public function testGetConnectionThatHasErrored(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Connection recently failed.');
@@ -289,7 +286,7 @@ class CollectionTest extends TestCase
         $collection->getConnection($identifier);
     }
 
-    public function testGetConnectionThatHasErroredButIsDueRetry()
+    public function testGetConnectionThatHasErroredButIsDueRetry(): void
     {
         $identifier = 'id-123';
         $command = 'stats';
@@ -308,7 +305,7 @@ class CollectionTest extends TestCase
         static::assertSame($connection, $collection->getConnection($identifier));
     }
 
-    public function testSendToAllConnections()
+    public function testSendToAllConnections(): void
     {
         $command = 'stats';
         $calls = 0;
@@ -331,7 +328,7 @@ class CollectionTest extends TestCase
         static::assertEquals(2, $calls);
     }
 
-    public function testSendToAllIgnoreErrors()
+    public function testSendToAllIgnoreErrors(): void
     {
         $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
@@ -347,7 +344,7 @@ class CollectionTest extends TestCase
         $collection->sendToAll($command);
     }
 
-    public function testSendToAllIgnoreErrorsOfNotFound()
+    public function testSendToAllIgnoreErrorsOfNotFound(): void
     {
         $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
@@ -363,7 +360,7 @@ class CollectionTest extends TestCase
         $collection->sendToAll($command);
     }
 
-    public function testSendToAllCallsSuccessCallback()
+    public function testSendToAllCallsSuccessCallback(): void
     {
         $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
@@ -407,7 +404,7 @@ class CollectionTest extends TestCase
         static::assertSame(1, $called);
     }
 
-    public function testSendToAllCallsFailureCallback()
+    public function testSendToAllCallsFailureCallback(): void
     {
         $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
@@ -455,7 +452,7 @@ class CollectionTest extends TestCase
         static::assertSame(1, $failed);
     }
 
-    public function testSendToOne()
+    public function testSendToOne(): void
     {
         $command = 'stats';
         $identifier1 = 'id-123';
@@ -473,7 +470,7 @@ class CollectionTest extends TestCase
         $collection->sendToOne($command);
     }
 
-    public function testSendToOneWhenAllConnectionsAreUsed()
+    public function testSendToOneWhenAllConnectionsAreUsed(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -498,7 +495,7 @@ class CollectionTest extends TestCase
         $collection->sendToOne($command);
     }
 
-    public function testSendToOneIgnoresErrors()
+    public function testSendToOneIgnoresErrors(): void
     {
         $command = 'stats';
         $identifier1 = 'id-123';
@@ -521,7 +518,7 @@ class CollectionTest extends TestCase
         $collection->sendToOne($command);
     }
 
-    public function testSendToOneThrowsTheLastError()
+    public function testSendToOneThrowsTheLastError(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -548,10 +545,9 @@ class CollectionTest extends TestCase
 
     /**
      * @param mixed $identifier
-     * @param array $methods
      * @return Connection|MockObject
      */
-    public function getMockConnection($identifier, array $methods = null)
+    public function getMockConnection($identifier, array $methods = null): Connection
     {
         $builder = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor();

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -74,7 +74,7 @@ class CollectionTest extends TestCase
         foreach ($collection as $connection) {
             $count++;
         }
-        static::assertEquals(2, $count);
+        static::assertSame(2, $count);
     }
 
     public function testArrayAggregateSkipsErroredConnections(): void
@@ -95,7 +95,7 @@ class CollectionTest extends TestCase
         foreach ($collection as $connection) {
             $count++;
         }
-        static::assertEquals(1, $count);
+        static::assertSame(1, $count);
     }
 
     public function testGetAvailableKeys(): void
@@ -325,7 +325,7 @@ class CollectionTest extends TestCase
 
         $collection = new Collection([$connection1, $connection2]);
         $collection->sendToAll($command);
-        static::assertEquals(2, $calls);
+        static::assertSame(2, $calls);
     }
 
     public function testSendToAllIgnoreErrors(): void
@@ -379,7 +379,7 @@ class CollectionTest extends TestCase
 
         $collection = new Collection([$connection1, $connection2]);
         $collection->sendToAll($command, [], $onSuccess);
-        static::assertEquals(2, $called);
+        static::assertSame(2, $called);
     }
 
     public function testSendToAllSuccessCallbackStopsIteration(): void
@@ -425,7 +425,7 @@ class CollectionTest extends TestCase
 
         $collection = new Collection([$connection1, $connection2]);
         $collection->sendToAll($command, [], null, $onFailure);
-        static::assertEquals(2, $failed);
+        static::assertSame(2, $failed);
     }
 
     public function testSendToAllFailureCallbackStopsIteration(): void

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -150,13 +150,13 @@ class CollectionTest extends TestCase
     public function testCanSendToExactConnection()
     {
         $identifier = 'id-123';
-        $command    = 'stats';
+        $command = 'stats';
         $connection = $this->getMockConnection($identifier);
         $connection->expects(static::once())
             ->method($command);
         $collection = new Collection([
             $connection,
-            $this->getMockConnection('id-456')
+            $this->getMockConnection('id-456'),
         ]);
         $collection->sendToExact($identifier, $command);
     }
@@ -166,7 +166,7 @@ class CollectionTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $identifier = 'id-123';
-        $command    = 'stats';
+        $command = 'stats';
         $connection = $this->getMockConnection($identifier);
         $connection->expects(static::any())
             ->method($command)
@@ -181,7 +181,7 @@ class CollectionTest extends TestCase
         $this->expectExceptionMessage('Connection recently failed.');
 
         $identifier = 'id-123';
-        $command    = 'stats';
+        $command = 'stats';
         $connection = $this->getMockConnection($identifier);
         $connection->expects(static::any())
             ->method($command)
@@ -198,12 +198,14 @@ class CollectionTest extends TestCase
     public function testGetConnectionThatHasErroredButIsDueRetry()
     {
         $identifier = 'id-123';
-        $command    = 'stats';
+        $command = 'stats';
         $connection = $this->getMockConnection($identifier);
         $connection->expects(static::any())
             ->method($command)
             ->willThrowException(new RuntimeException());
-        $collection = new Collection([$connection], $this->strategy, ['retry_delay' => 0]);
+        $collection = new Collection([$connection], $this->strategy, [
+            'retry_delay' => 0,
+        ]);
         try {
             $collection->sendToExact($identifier, $command);
         } catch (\Exception $e) {
@@ -214,9 +216,9 @@ class CollectionTest extends TestCase
 
     public function testSendToAllConnections()
     {
-        $command    = 'stats';
-        $calls      = 0;
-        $callback   = function () use (&$calls) {
+        $command = 'stats';
+        $calls = 0;
+        $callback = function () use (&$calls) {
             $calls++;
         };
 
@@ -237,7 +239,7 @@ class CollectionTest extends TestCase
 
     public function testSendToAllIgnoreErrors()
     {
-        $command     = 'stats';
+        $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
         $connection1->expects(static::once())
             ->method($command);
@@ -253,7 +255,7 @@ class CollectionTest extends TestCase
 
     public function testSendToAllIgnoreErrorsOfNotFound()
     {
-        $command     = 'stats';
+        $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
         $connection1->expects(static::once())
             ->method($command);
@@ -269,7 +271,7 @@ class CollectionTest extends TestCase
 
     public function testSendToAllCallsSuccessCallback()
     {
-        $command     = 'stats';
+        $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
         $connection1->expects(static::any())
             ->method($command);
@@ -290,7 +292,7 @@ class CollectionTest extends TestCase
 
     public function testSendToAllCallsFailureCallback()
     {
-        $command     = 'stats';
+        $command = 'stats';
         $connection1 = $this->getMockConnection('id-123');
         $connection1->expects(static::any())
             ->method($command)
@@ -313,7 +315,7 @@ class CollectionTest extends TestCase
 
     public function testSendToOne()
     {
-        $command     = 'stats';
+        $command = 'stats';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::once())
@@ -333,7 +335,7 @@ class CollectionTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $command     = 'stats';
+        $command = 'stats';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())
@@ -356,7 +358,7 @@ class CollectionTest extends TestCase
 
     public function testSendToOneIgnoresErrors()
     {
-        $command     = 'stats';
+        $command = 'stats';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())
@@ -381,7 +383,7 @@ class CollectionTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $command     = 'stats';
+        $command = 'stats';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())

--- a/tests/Pool/RandomStrategyTest.php
+++ b/tests/Pool/RandomStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -7,19 +9,19 @@ use PHPUnit\Framework\TestCase;
 
 class RandomStrategyTest extends TestCase
 {
-    public function testImplementsSelectionStrategyInterface()
+    public function testImplementsSelectionStrategyInterface(): void
     {
         static::assertInstanceOf(SelectionStrategyInterface::class, new RandomStrategy());
     }
 
-    public function testFailsWhenGivenEmptyCollection()
+    public function testFailsWhenGivenEmptyCollection(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         (new RandomStrategy())->pickOne([]);
     }
 
-    public function testAllowsContinuousSelection()
+    public function testAllowsContinuousSelection(): void
     {
         $keys = ['host123', 'host456', 'host789'];
         $strategy = new RandomStrategy();
@@ -29,7 +31,7 @@ class RandomStrategyTest extends TestCase
         static::assertContains($strategy->pickOne($keys), $keys);
     }
 
-    public function testWithDifferingCollections()
+    public function testWithDifferingCollections(): void
     {
         $strategy = new RandomStrategy();
 

--- a/tests/Pool/RoundRobinStrategyTest.php
+++ b/tests/Pool/RoundRobinStrategyTest.php
@@ -22,7 +22,7 @@ class RoundRobinStrategyTest extends TestCase
         for ($i = 0; $i < count($keys); $i++) {
             $strategy->pickOne($keys);
         }
-        static::assertEquals($firstHost, $strategy->pickOne($keys));
+        static::assertSame($firstHost, $strategy->pickOne($keys));
     }
 
     public function testFailsWhenGivenEmptyCollection(): void
@@ -41,6 +41,6 @@ class RoundRobinStrategyTest extends TestCase
 
         $newHost = 'host456';
         $keys[] = $newHost;
-        static::assertEquals($newHost, $strategy->pickOne($keys));
+        static::assertSame($newHost, $strategy->pickOne($keys));
     }
 }

--- a/tests/Pool/RoundRobinStrategyTest.php
+++ b/tests/Pool/RoundRobinStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk\Pool;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -7,12 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 class RoundRobinStrategyTest extends TestCase
 {
-    public function testImplementsSelectionStrategyInterface()
+    public function testImplementsSelectionStrategyInterface(): void
     {
         static::assertInstanceOf(SelectionStrategyInterface::class, new RoundRobinStrategy());
     }
 
-    public function testAllowsContinuousSelection()
+    public function testAllowsContinuousSelection(): void
     {
         $firstHost = 'host123';
         $keys = [$firstHost, 'host456', 'host789'];
@@ -23,14 +25,14 @@ class RoundRobinStrategyTest extends TestCase
         static::assertEquals($firstHost, $strategy->pickOne($keys));
     }
 
-    public function testFailsWhenGivenEmptyCollection()
+    public function testFailsWhenGivenEmptyCollection(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         (new RoundRobinStrategy())->pickOne([]);
     }
 
-    public function testWithDifferingCollections()
+    public function testWithDifferingCollections(): void
     {
         $strategy = new RoundRobinStrategy();
 

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
@@ -10,17 +12,14 @@ use PHPUnit\Framework\TestCase;
 
 class PoolTest extends TestCase
 {
-    /**
-     * @var Pool
-     */
-    protected $pool;
+    protected Pool $pool;
 
     /**
      * @var Collection|MockObject
      */
-    protected $collection;
+    protected MockObject $collection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -28,14 +27,7 @@ class PoolTest extends TestCase
         $this->pool = new Pool($this->collection);
     }
 
-    protected function tearDown()
-    {
-        parent::tearDown();
-        $this->servers = null;
-        $this->pool = null;
-    }
-
-    public function testDisconnectCallsAllConnections()
+    public function testDisconnectCallsAllConnections(): void
     {
         $connection = $this->createMock(Connection::class);
         $connection->expects(static::exactly(2))
@@ -49,10 +41,9 @@ class PoolTest extends TestCase
     }
 
     /**
-     * @param bool $expected
      * @dataProvider disconnectReturnsValueDataProvider
      */
-    public function testDisconnectReturnsValue($expected, array $returnValues)
+    public function testDisconnectReturnsValue(bool $expected, array $returnValues): void
     {
         $connection = $this->createMock(Connection::class);
         $connection->expects(static::any())
@@ -65,7 +56,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->disconnect());
     }
 
-    public function disconnectReturnsValueDataProvider()
+    public function disconnectReturnsValueDataProvider(): array
     {
         return [
             [true, [true, true]],
@@ -75,7 +66,7 @@ class PoolTest extends TestCase
         ];
     }
 
-    public function testUseTubeCallsAllConnections()
+    public function testUseTubeCallsAllConnections(): void
     {
         $tube = 'test-tube';
         $this->collection->expects(static::once())
@@ -83,19 +74,19 @@ class PoolTest extends TestCase
         $this->pool->useTube($tube);
     }
 
-    public function testIgnoreDoesNotAllowLessThanOneWatching()
+    public function testIgnoreDoesNotAllowLessThanOneWatching(): void
     {
         // 'default' tube is already being watched
         static::assertFalse($this->pool->ignore('default'));
     }
 
-    public function testIgnore()
+    public function testIgnore(): void
     {
         $this->pool->watch('test-tube');
         static::assertEquals(1, $this->pool->ignore('default'));
     }
 
-    public function testPutSuccess()
+    public function testPutSuccess(): void
     {
         $connection = $this->createMock(Connection::class);
         $this->collection->expects(static::once())
@@ -107,7 +98,7 @@ class PoolTest extends TestCase
         $this->pool->put('myJobData');
     }
 
-    public function testPutReturnsJobIdContainingTheServerIdentifier()
+    public function testPutReturnsJobIdContainingTheServerIdentifier(): void
     {
         $host = 'host123';
         $connection = $this->createMockConnection($host);
@@ -120,7 +111,7 @@ class PoolTest extends TestCase
         static::assertContains($host, $this->pool->put('myJobData'));
     }
 
-    public function testPutReturnsJobIdContainingTheOriginalJobId()
+    public function testPutReturnsJobIdContainingTheOriginalJobId(): void
     {
         $jobId = '432';
         $connection = $this->createMockConnection('host:123');
@@ -133,7 +124,7 @@ class PoolTest extends TestCase
         static::assertContains($jobId, $this->pool->put('myJobData'));
     }
 
-    public function testPutTotalFailure()
+    public function testPutTotalFailure(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -146,7 +137,7 @@ class PoolTest extends TestCase
     /**
      * @medium
      */
-    public function testReserveWithNoJobsDoesNotTakeLongerThanTimeout()
+    public function testReserveWithNoJobsDoesNotTakeLongerThanTimeout(): void
     {
         $connection = $this->createMockConnection('host:123');
         $this->collection->expects(static::any())
@@ -165,7 +156,7 @@ class PoolTest extends TestCase
         static::assertLessThanOrEqual(3, $totalTime);
     }
 
-    public function testReserve()
+    public function testReserve(): void
     {
         $jobId = '123';
         $host = 'host:123';
@@ -191,7 +182,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->reserve());
     }
 
-    public function testReserveWithNoJobsOnFirstServer()
+    public function testReserveWithNoJobsOnFirstServer(): void
     {
         $jobId = '123';
         $host = 'host:123';
@@ -220,7 +211,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->reserve());
     }
 
-    public function testReserveWithFailingServer()
+    public function testReserveWithFailingServer(): void
     {
         $jobId = '123';
         $host = 'host:123';
@@ -249,7 +240,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->reserve());
     }
 
-    public function testPoolIdWithInvalidFormat()
+    public function testPoolIdWithInvalidFormat(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -257,10 +248,9 @@ class PoolTest extends TestCase
     }
 
     /**
-     * @param string $method
      * @dataProvider methodsWithJobIdDataProvider
      */
-    public function testMethodsWithJobId($method)
+    public function testMethodsWithJobId(string $method): void
     {
         $host = 'host:456';
         $jobId = '123';
@@ -274,12 +264,12 @@ class PoolTest extends TestCase
         $this->pool->{$method}("{$host}.{$jobId}");
     }
 
-    public function methodsWithJobIdDataProvider()
+    public function methodsWithJobIdDataProvider(): array
     {
         return [['delete'], ['release'], ['bury'], ['touch']];
     }
 
-    public function testPeek()
+    public function testPeek(): void
     {
         $host = 'host:456';
         $jobId = '123';
@@ -304,7 +294,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->peek("{$host}.{$jobId}"));
     }
 
-    public function testPeekReady()
+    public function testPeekReady(): void
     {
         $host = 'host:123';
         $jobId = '123';
@@ -329,7 +319,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->peekReady());
     }
 
-    public function testPeekReadyWithNoReadyJobs()
+    public function testPeekReadyWithNoReadyJobs(): void
     {
         $this->collection->expects(static::any())
             ->method('sendToOne')
@@ -340,7 +330,7 @@ class PoolTest extends TestCase
         static::assertFalse($this->pool->peekReady());
     }
 
-    public function testPeekDelayed()
+    public function testPeekDelayed(): void
     {
         $host = 'host:123';
         $jobId = '123';
@@ -365,7 +355,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->peekDelayed());
     }
 
-    public function testPeekDelayedWithNoDelayedJobs()
+    public function testPeekDelayedWithNoDelayedJobs(): void
     {
         $this->collection->expects(static::any())
             ->method('sendToOne')
@@ -376,7 +366,7 @@ class PoolTest extends TestCase
         static::assertFalse($this->pool->peekDelayed());
     }
 
-    public function testPeekBuried()
+    public function testPeekBuried(): void
     {
         $host = 'host:123';
         $jobId = '123';
@@ -401,7 +391,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->peekBuried());
     }
 
-    public function testPeekBuriedWithNoBuriedJobs()
+    public function testPeekBuriedWithNoBuriedJobs(): void
     {
         $this->collection->expects(static::any())
             ->method('sendToOne')
@@ -409,7 +399,7 @@ class PoolTest extends TestCase
         static::assertFalse($this->pool->peekBuried());
     }
 
-    public function testStats()
+    public function testStats(): void
     {
         $noOfServers = 3;
         $ready = 2;
@@ -437,7 +427,7 @@ class PoolTest extends TestCase
         );
     }
 
-    public function testStatsJob()
+    public function testStatsJob(): void
     {
         $host = 'host:123';
         $jobId = '123';
@@ -462,7 +452,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->statsJob($hostJobId));
     }
 
-    public function testStatsTube()
+    public function testStatsTube(): void
     {
         $noOfServers = 3;
         $ready = 2;
@@ -491,11 +481,9 @@ class PoolTest extends TestCase
     }
 
     /**
-     * @param integer $kickAmount
-     * @param integer $expected
      * @dataProvider kickDataProvider
      */
-    public function testKick(array $kickValues, $kickAmount, $expected)
+    public function testKick(array $kickValues, int $kickAmount, int $expected): void
     {
         $connection = $this->createMockConnection('host:123');
         $at = 0;
@@ -527,7 +515,7 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $this->pool->kick($kickAmount));
     }
 
-    public function kickDataProvider()
+    public function kickDataProvider(): array
     {
         return [
             [[1, 2, 4], 100, 7],
@@ -539,7 +527,7 @@ class PoolTest extends TestCase
         ];
     }
 
-    public function testListTubes()
+    public function testListTubes(): void
     {
         $expected = ['test1', 'test2', 'test3', 'test4'];
 
@@ -565,39 +553,39 @@ class PoolTest extends TestCase
         static::assertEquals($expected, $actual);
     }
 
-    public function testListTubeUsed()
+    public function testListTubeUsed(): void
     {
         $tube = 'test-tube';
         $this->pool->useTube($tube);
         static::assertSame($tube, $this->pool->listTubeUsed());
     }
 
-    public function testListTubesWatchDefaultState()
+    public function testListTubesWatchDefaultState(): void
     {
         static::assertEquals(['default'], $this->pool->listTubesWatched());
     }
 
-    public function testListTubesWatched()
+    public function testListTubesWatched(): void
     {
         $this->pool->watch('test');
         static::assertEquals(['default', 'test'], $this->pool->listTubesWatched());
     }
 
-    public function testCombineIdIsNotTheJobId()
+    public function testCombineIdIsNotTheJobId(): void
     {
         $jobId = 123;
         $connection = $this->createMockConnection('host');
         static::assertNotEquals($jobId, $this->pool->combineId($connection, $jobId));
     }
 
-    public function testCombineIdContainsJob()
+    public function testCombineIdContainsJob(): void
     {
         $jobId = 123;
         $connection = $this->createMockConnection('host');
         static::assertContains((string)$jobId, $this->pool->combineId($connection, $jobId));
     }
 
-    public function testCombineAndSplitReturnCorrectJob()
+    public function testCombineAndSplitReturnCorrectJob(): void
     {
         $jobId = 234;
         $connection = $this->createMockConnection('127.0.0.1');
@@ -607,7 +595,7 @@ class PoolTest extends TestCase
         static::assertEquals($jobId, $actualJobId);
     }
 
-    public function testCombineAndSplitReturnCorrectHost()
+    public function testCombineAndSplitReturnCorrectHost(): void
     {
         $host = '127.0.0.1';
         $connection = $this->createMockConnection($host);
@@ -618,10 +606,9 @@ class PoolTest extends TestCase
     }
 
     /**
-     * @param string $host
      * @return Connection|MockObject
      */
-    protected function createMockConnection($host)
+    protected function createMockConnection(string $host): Connection
     {
         $connection = $this->createMock(Connection::class);
         $connection->expects(static::any())

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -53,7 +53,7 @@ class PoolTest extends TestCase
         $this->collection->expects(static::any())
             ->method('getIterator')
             ->willReturn($collection);
-        static::assertEquals($expected, $this->pool->disconnect());
+        static::assertSame($expected, $this->pool->disconnect());
     }
 
     public function disconnectReturnsValueDataProvider(): array
@@ -83,7 +83,7 @@ class PoolTest extends TestCase
     public function testIgnore(): void
     {
         $this->pool->watch('test-tube');
-        static::assertEquals(1, $this->pool->ignore('default'));
+        static::assertSame(1, $this->pool->ignore('default'));
     }
 
     public function testPutSuccess(): void
@@ -179,7 +179,7 @@ class PoolTest extends TestCase
                 'connection' => $connection,
                 'response' => $response,
             ]);
-        static::assertEquals($expected, $this->pool->reserve());
+        static::assertSame($expected, $this->pool->reserve());
     }
 
     public function testReserveWithNoJobsOnFirstServer(): void
@@ -208,7 +208,7 @@ class PoolTest extends TestCase
                 'connection' => $connection,
                 'response' => $response,
             ]);
-        static::assertEquals($expected, $this->pool->reserve());
+        static::assertSame($expected, $this->pool->reserve());
     }
 
     public function testReserveWithFailingServer(): void
@@ -237,7 +237,7 @@ class PoolTest extends TestCase
                 'connection' => $connection,
                 'response' => $response,
             ]);
-        static::assertEquals($expected, $this->pool->reserve());
+        static::assertSame($expected, $this->pool->reserve());
     }
 
     public function testPoolIdWithInvalidFormat(): void
@@ -291,7 +291,7 @@ class PoolTest extends TestCase
                 'response' => $response,
             ]);
 
-        static::assertEquals($expected, $this->pool->peek("{$host}.{$jobId}"));
+        static::assertSame($expected, $this->pool->peek("{$host}.{$jobId}"));
     }
 
     public function testPeekReady(): void
@@ -316,7 +316,7 @@ class PoolTest extends TestCase
                 'response' => $response,
             ]);
 
-        static::assertEquals($expected, $this->pool->peekReady());
+        static::assertSame($expected, $this->pool->peekReady());
     }
 
     public function testPeekReadyWithNoReadyJobs(): void
@@ -352,7 +352,7 @@ class PoolTest extends TestCase
                 'response' => $response,
             ]);
 
-        static::assertEquals($expected, $this->pool->peekDelayed());
+        static::assertSame($expected, $this->pool->peekDelayed());
     }
 
     public function testPeekDelayedWithNoDelayedJobs(): void
@@ -388,7 +388,7 @@ class PoolTest extends TestCase
                 'response' => $response,
             ]);
 
-        static::assertEquals($expected, $this->pool->peekBuried());
+        static::assertSame($expected, $this->pool->peekBuried());
     }
 
     public function testPeekBuriedWithNoBuriedJobs(): void
@@ -418,7 +418,7 @@ class PoolTest extends TestCase
                     ]);
                 }
             });
-        static::assertEquals(
+        static::assertSame(
             [
                 'current-jobs-ready' => ($ready * $noOfServers),
                 'some-other' => ($other * $noOfServers),
@@ -449,7 +449,7 @@ class PoolTest extends TestCase
                 'connection' => $connection,
                 'response' => $response,
             ]);
-        static::assertEquals($expected, $this->pool->statsJob($hostJobId));
+        static::assertSame($expected, $this->pool->statsJob($hostJobId));
     }
 
     public function testStatsTube(): void
@@ -471,7 +471,7 @@ class PoolTest extends TestCase
                     ]);
                 }
             });
-        static::assertEquals(
+        static::assertSame(
             [
                 'current-jobs-ready' => ($ready * $noOfServers),
                 'some-other' => ($other * $noOfServers),
@@ -488,7 +488,7 @@ class PoolTest extends TestCase
         $connection = $this->createMockConnection('host:123');
         $at = 0;
         foreach ($kickValues as $index => $kickValue) {
-            if ($kickValue == 0) {
+            if ($kickValue === 0) {
                 continue;
             }
             $connection->expects(static::at($at++))
@@ -512,7 +512,7 @@ class PoolTest extends TestCase
                 }
             });
 
-        static::assertEquals($expected, $this->pool->kick($kickAmount));
+        static::assertSame($expected, $this->pool->kick($kickAmount));
     }
 
     public function kickDataProvider(): array
@@ -550,7 +550,7 @@ class PoolTest extends TestCase
 
         $actual = $this->pool->listTubes();
         sort($actual); // this is so they match
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testListTubeUsed(): void
@@ -562,20 +562,20 @@ class PoolTest extends TestCase
 
     public function testListTubesWatchDefaultState(): void
     {
-        static::assertEquals(['default'], $this->pool->listTubesWatched());
+        static::assertSame(['default'], $this->pool->listTubesWatched());
     }
 
     public function testListTubesWatched(): void
     {
         $this->pool->watch('test');
-        static::assertEquals(['default', 'test'], $this->pool->listTubesWatched());
+        static::assertSame(['default', 'test'], $this->pool->listTubesWatched());
     }
 
     public function testCombineIdIsNotTheJobId(): void
     {
         $jobId = 123;
         $connection = $this->createMockConnection('host');
-        static::assertNotEquals($jobId, $this->pool->combineId($connection, $jobId));
+        static::assertNotSame($jobId, $this->pool->combineId($connection, $jobId));
     }
 
     public function testCombineIdContainsJob(): void
@@ -592,7 +592,7 @@ class PoolTest extends TestCase
 
         $poolId = $this->pool->combineId($connection, $jobId);
         [$actualHost, $actualJobId] = $this->pool->splitId($poolId);
-        static::assertEquals($jobId, $actualJobId);
+        static::assertSame($jobId, $actualJobId);
     }
 
     public function testCombineAndSplitReturnCorrectHost(): void
@@ -602,7 +602,7 @@ class PoolTest extends TestCase
 
         $poolId = $this->pool->combineId($connection, 123);
         [$actualHost, ] = $this->pool->splitId($poolId);
-        static::assertEquals($host, $actualHost);
+        static::assertSame($host, $actualHost);
     }
 
     /**

--- a/tests/ValidateTraitTest.php
+++ b/tests/ValidateTraitTest.php
@@ -1,25 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ValidateTraitTest extends TestCase
 {
     /**
-     * @var ValidateTrait
+     * @var ValidateTrait|MockObject
      */
-    protected $validate;
+    protected MockObject $validate;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->validate = $this->getMockForTrait(ValidateTrait::class);
         parent::setUp();
     }
 
-    public function testValidPriority()
+    public function testValidPriority(): void
     {
         static::assertTrue($this->validate->validatePriority(123));
     }
@@ -28,69 +31,78 @@ class ValidateTraitTest extends TestCase
      * @param mixed $priority
      * @dataProvider invalidPriorityDataProvider
      */
-    public function testInvalidPriority($priority)
+    public function testInvalidPriority($priority, string $exception): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException($exception);
 
         $this->validate->validatePriority($priority);
     }
 
-    public function invalidPriorityDataProvider()
+    public function invalidPriorityDataProvider(): array
     {
-        return [['string'], [-123], [12.43]];
+        // Priority must be integer between 0 and 4,294,967,295
+        return [
+            'string' => ['string', \TypeError::class],
+            'below zero' => [-123, InvalidArgumentException::class],
+            'decimal' => [12.43, \TypeError::class],
+            'over max' => [4294967296, InvalidArgumentException::class],
+        ];
     }
 
-    public function testValidTubeName()
+    public function testValidTubeName(): void
     {
         static::assertTrue($this->validate->validateTubeName('mytube'));
     }
 
     /**
-     * @param mixed $name
      * @dataProvider invalidTubeNameDataProvider
      */
-    public function testInvalidTubeName($name)
+    public function testInvalidTubeName(?string $name, string $exception): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException($exception);
 
         $this->validate->validateTubeName($name);
     }
 
-    public function invalidTubeNameDataProvider()
+    public function invalidTubeNameDataProvider(): array
     {
-        return [[''], [null], [str_repeat('.', ConnectionInterface::MAX_TUBE_LENGTH + 1)]];
+        return [
+            'empty' => ['', InvalidArgumentException::class],
+            'null' => [null, \TypeError::class],
+            'too long' => [str_repeat('.', ConnectionInterface::MAX_TUBE_LENGTH + 1), InvalidArgumentException::class],
+        ];
     }
 
     /**
      * @param mixed $data
      * @dataProvider validJobDataDataProvider
      */
-    public function testValidJobData($data)
+    public function testValidJobData($data): void
     {
         static::assertTrue($this->validate->validateJobData($data));
     }
 
-    public function validJobDataDataProvider()
+    public function validJobDataDataProvider(): array
     {
         return [
-            ['Foo Bar Baz'],
-            [['my' => 'array']],
-            [new \stdClass()],
-            [1234],
+            'string' => ['Foo Bar Baz'],
+            'array' => [['my' => 'array']],
+            'object' => [new \stdClass()],
+            'integer' => [1234],
         ];
     }
 
     /**
      * @dataProvider invalidJobDataDataProvider
      */
-    public function testInvalidJobData($data)
+    public function testInvalidJobData($data): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         $this->validate->validateJobData($data);
     }
 
-    public function invalidJobDataDataProvider()
+    public function invalidJobDataDataProvider(): array
     {
         return [[''], [str_pad('', ConnectionInterface::MAX_JOB_LENGTH + 1)]];
     }

--- a/tests/ValidateTraitTest.php
+++ b/tests/ValidateTraitTest.php
@@ -76,7 +76,7 @@ class ValidateTraitTest extends TestCase
             ['Foo Bar Baz'],
             [['my' => 'array']],
             [new \stdClass()],
-            [1234]
+            [1234],
         ];
     }
 


### PR DESCRIPTION
- Add type declarations for methods and properties and strict types directive.
  - Complements existing major version change to drop support for PHP versions < 7.4 .
- Split string behaviour of `Command\Peek` to `Command\PeekStatus`, leaving `Command\Peek` to just handle job IDs.
- Restrict `Collection::send*` methods to only accept commands defined in `ConnectionInterface`.
  - Prevent other connection methods being called.