### PR TITLE
Add validation for delay and TTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   where possible. Some methods return mixed type so docblocks are still used.
 - Add type definitions docblocks for `Collection::sendToAll()` callbacks.
   There is no change to functionality, but this better explains how these work.
+- `put()` and `release()` validate the delay and TTR parameters for integers
+  in a valid range.
 ### Fixed
 - `Pool::ignore()` incorrectly updated its own cache of watched tubes, meaning
   multiple calls may have had unexpected results.
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: Restrict `Collection::send*` methods to only accept commands
   defined in `ConnectionInterface`, rather than allowing any method to be called
   on the connection.
+- **BC break**: `ValidateTrait::validatePriority()` no longer returns a value.
 - Order of stats in `server:stats` CLI command to match order from Beanstalkd.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v7.3 as they are no longer

--- a/src/Command/Put.php
+++ b/src/Command/Put.php
@@ -29,6 +29,8 @@ class Put implements CommandInterface
     {
         $this->validateJobData($data);
         $this->validatePriority($priority);
+        $this->validateDelay($delay);
+        $this->validateTtr($ttr);
 
         $this->data = (string)$data;
         $this->priority = $priority;

--- a/src/Command/Release.php
+++ b/src/Command/Release.php
@@ -27,6 +27,7 @@ class Release implements CommandInterface
     public function __construct(int $id, int $priority, int $delay)
     {
         $this->validatePriority($priority);
+        $this->validateDelay($delay);
 
         $this->id = $id;
         $this->priority = $priority;

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -20,7 +20,11 @@ interface ConnectionInterface
 
     public const MAX_TUBE_LENGTH = 200;
 
-    public const MAX_PRIORITY = 4294967295; // 2^32
+    public const MAX_PRIORITY = 4_294_967_295; // 2^32 - 1
+
+    public const MAX_DELAY = 4_294_967_295; // 2^32 - 1
+
+    public const MAX_TTR = 4_294_967_295; // 2^32 - 1
 
     public function getName(): string;
 

--- a/src/ValidateTrait.php
+++ b/src/ValidateTrait.php
@@ -13,8 +13,12 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
  */
 trait ValidateTrait
 {
-    public function validatePriority(int $priority): bool
+    public function validatePriority(int $priority): void
     {
+        /*
+         * https://raw.githubusercontent.com/beanstalkd/beanstalkd/master/doc/protocol.txt
+         * "<pri> is an integer < 2**32"
+         */
         $options = [
             'options' => [
                 'min_range' => 0,
@@ -24,7 +28,40 @@ trait ValidateTrait
         if (filter_var($priority, FILTER_VALIDATE_INT, $options) === false) {
             throw new InvalidArgumentException('Priority is not within acceptable range.');
         }
-        return true;
+    }
+
+    public function validateDelay(int $delay): void
+    {
+        /*
+         * https://raw.githubusercontent.com/beanstalkd/beanstalkd/master/doc/protocol.txt
+         * "<delay> is an integer number ... Maximum delay is 2**32-1"
+         */
+        $options = [
+            'options' => [
+                'min_range' => 0,
+                'max_range' => ConnectionInterface::MAX_DELAY,
+            ],
+        ];
+        if (filter_var($delay, FILTER_VALIDATE_INT, $options) === false) {
+            throw new InvalidArgumentException('Delay is not within acceptable range.');
+        }
+    }
+
+    public function validateTtr(int $ttr): void
+    {
+        /*
+         * https://raw.githubusercontent.com/beanstalkd/beanstalkd/master/doc/protocol.txt
+         * "<ttr> -- time to run -- is an integer number ... Maximum ttr is 2**32-1"
+         */
+        $options = [
+            'options' => [
+                'min_range' => 0,
+                'max_range' => ConnectionInterface::MAX_TTR,
+            ],
+        ];
+        if (filter_var($ttr, FILTER_VALIDATE_INT, $options) === false) {
+            throw new InvalidArgumentException('TTR is not within acceptable range.');
+        }
     }
 
     public function validateTubeName(string $name): bool

--- a/tests/Command/PutTest.php
+++ b/tests/Command/PutTest.php
@@ -29,6 +29,22 @@ class PutTest extends CommandTestCase
         new Put('data', 4294967296, 123, 456);
     }
 
+    public function testWithInvalidDelay(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        // Delay must be integer between 0 and 4,294,967,295
+        new Put('data', 123, 4294967296, 456);
+    }
+
+    public function testWithInvalidTtr(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        // TTR must be integer between 0 and 4,294,967,295
+        new Put('data', 123, 456, 4294967296);
+    }
+
     public function testSuccessfulCommand(): void
     {
         $id = 123;

--- a/tests/Command/ReleaseTest.php
+++ b/tests/Command/ReleaseTest.php
@@ -28,6 +28,14 @@ class ReleaseTest extends CommandTestCase
         new Release(123, 4294967296, 456);
     }
 
+    public function testWithInvalidDelay(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        // Delay must be integer between 0 and 4,294,967,295
+        new Release(123, 456, 4294967296);
+    }
+
     public function testSuccessfulCommand(): void
     {
         $this->socket->expects(static::any())

--- a/tests/ValidateTraitTest.php
+++ b/tests/ValidateTraitTest.php
@@ -24,7 +24,10 @@ class ValidateTraitTest extends TestCase
 
     public function testValidPriority(): void
     {
-        static::assertTrue($this->validate->validatePriority(123));
+        // No exceptions are thrown
+        $this->expectNotToPerformAssertions();
+
+        $this->validate->validatePriority(123);
     }
 
     /**
@@ -47,6 +50,44 @@ class ValidateTraitTest extends TestCase
             'decimal' => [12.43, \TypeError::class],
             'over max' => [4294967296, InvalidArgumentException::class],
         ];
+    }
+
+    public function testValidDelay(): void
+    {
+        // No exceptions are thrown
+        $this->expectNotToPerformAssertions();
+
+        $this->validate->validateDelay(123);
+    }
+
+    /**
+     * @param mixed $delay
+     * @dataProvider invalidPriorityDataProvider
+     */
+    public function testInvalidDelay($delay, string $exception): void
+    {
+        $this->expectException($exception);
+
+        $this->validate->validateDelay($delay);
+    }
+
+    public function testValidTtr(): void
+    {
+        // No exceptions are thrown
+        $this->expectNotToPerformAssertions();
+
+        $this->validate->validateTtr(123);
+    }
+
+    /**
+     * @param mixed $ttr
+     * @dataProvider invalidPriorityDataProvider
+     */
+    public function testInvalidTtr($ttr, string $exception): void
+    {
+        $this->expectException($exception);
+
+        $this->validate->validateTtr($ttr);
     }
 
     public function testValidTubeName(): void


### PR DESCRIPTION
- Add validation for delay and TTR.
- Remove return value from `validatePriority()`.