### PR TITLE
Remove union false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: Restrict `Collection::send*` methods to only accept commands
   defined in `ConnectionInterface`, rather than allowing any method to be called
   on the connection.
+- **BC break**: Replace union false return types with nullable types. For
+  example, a method that previously hinted `array|false` is now typed `?array`, 
+  and will return `null` for the same state it previously returned `false`.
 - Order of stats in `server:stats` CLI command to match order from Beanstalkd.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v7.3 as they are no longer

--- a/src/Command/Reserve.php
+++ b/src/Command/Reserve.php
@@ -31,10 +31,7 @@ class Reserve implements CommandInterface
         return sprintf('reserve-with-timeout %d', $this->timeout);
     }
 
-    /**
-     * @return array|false
-     */
-    public function process(SocketInterface $socket)
+    public function process(SocketInterface $socket): ?array
     {
         $socket->write($this->getCommand());
         $status = strtok($socket->read(), ' ');
@@ -51,7 +48,7 @@ class Reserve implements CommandInterface
 
             case 'DEADLINE_SOON':
             case 'TIMED_OUT':
-                return false;
+                return null;
 
             default:
                 throw new CommandException("Reserve failed '{$status}'");

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -78,10 +78,7 @@ class Connection implements ConnectionInterface
             ->process($this->getSocket());
     }
 
-    /**
-     * @return array|false
-     */
-    public function reserve(?int $timeout = null)
+    public function reserve(?int $timeout = null): ?array
     {
         $jobData = (new Command\Reserve($timeout))
             ->process($this->getSocket());
@@ -144,14 +141,11 @@ class Connection implements ConnectionInterface
         return $this;
     }
 
-    /**
-     * @return int|false
-     */
-    public function ignore(string $tube)
+    public function ignore(string $tube): ?int
     {
         if (isset($this->watching[$tube])) {
             if (count($this->watching) === 1) {
-                return false;
+                return null;
             }
 
             (new Command\Ignore($tube))
@@ -172,48 +166,33 @@ class Connection implements ConnectionInterface
         return $jobData;
     }
 
-    /**
-     * @return array|false
-     */
-    public function peekReady()
+    public function peekReady(): ?array
     {
         return $this->peekStatus(Command\PeekStatus::READY);
     }
 
-    /**
-     * @return array|false
-     */
-    public function peekDelayed()
+    public function peekDelayed(): ?array
     {
         return $this->peekStatus(Command\PeekStatus::DELAYED);
     }
 
-    /**
-     * @return array|false
-     */
-    public function peekBuried()
+    public function peekBuried(): ?array
     {
         return $this->peekStatus(Command\PeekStatus::BURIED);
     }
 
-    /**
-     * @return array|false
-     */
-    protected function peekStatus(string $status)
+    protected function peekStatus(string $status): ?array
     {
         try {
             $jobData = (new Command\PeekStatus($status))
                 ->process($this->getSocket());
             return $jobData;
         } catch (NotFoundException $e) {
-            return false;
+            return null;
         }
     }
 
-    /**
-     * @return array|false
-     */
-    public function stats()
+    public function stats(): array
     {
         return (new Command\Stats())
             ->process($this->getSocket());
@@ -228,10 +207,7 @@ class Connection implements ConnectionInterface
             ->process($this->getSocket());
     }
 
-    /**
-     * @return array|false
-     */
-    public function statsTube(string $tube)
+    public function statsTube(string $tube): ?array
     {
         return (new Command\StatsTube($tube))
             ->process($this->getSocket());

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -38,10 +38,7 @@ interface ConnectionInterface
         int $ttr = self::DEFAULT_TTR
     );
 
-    /**
-     * @return array|false
-     */
-    public function reserve(?int $timeout = null);
+    public function reserve(?int $timeout = null): ?array;
 
     /**
      * @param string|int $id
@@ -66,9 +63,9 @@ interface ConnectionInterface
     public function watch(string $tube): self;
 
     /**
-     * @return int|false Number of tubes being watched or false
+     * @return int|null Number of tubes being watched or null when last tube cannot be ignored
      */
-    public function ignore(string $tube);
+    public function ignore(string $tube): ?int;
 
     /**
      * @param string|int $id
@@ -80,32 +77,17 @@ interface ConnectionInterface
      */
     public function statsJob($id): array;
 
-    /**
-     * @return array|false
-     */
-    public function peekReady();
+    public function peekReady(): ?array;
 
-    /**
-     * @return array|false
-     */
-    public function peekDelayed();
+    public function peekDelayed(): ?array;
 
-    /**
-     * @return array|false
-     */
-    public function peekBuried();
+    public function peekBuried(): ?array;
 
     public function kick(int $quantity): int;
 
-    /**
-     * @return array|false
-     */
-    public function statsTube(string $tube);
+    public function statsTube(string $tube): ?array;
 
-    /**
-     * @return array|false
-     */
-    public function stats();
+    public function stats(): ?array;
 
     public function listTubes(): array;
 

--- a/src/Console/TubePeekCommand.php
+++ b/src/Console/TubePeekCommand.php
@@ -49,7 +49,7 @@ class TubePeekCommand extends AbstractCommand
                 throw new InvalidArgumentException("Specified status '{$status}' is not valid.");
         }
 
-        if ($job === false) {
+        if ($job === null) {
             $output->writeln("No jobs found in '{$status}' status.");
         } else {
             $this->displayJob($job, $output);

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -64,10 +64,7 @@ class Pool implements ConnectionInterface
         return $this->combineId($result['connection'], (int)$result['response']);
     }
 
-    /**
-     * @return array|false
-     */
-    public function reserve(?int $timeout = null)
+    public function reserve(?int $timeout = null): ?array
     {
         $startTime = time();
         do {
@@ -77,7 +74,7 @@ class Pool implements ConnectionInterface
             foreach ($keys as $key) {
                 try {
                     $result = $this->collection->sendToExact($key, 'reserve', [0]);
-                    if ($result['response'] === false) {
+                    if ($result['response'] === null) {
                         continue;
                     }
 
@@ -91,7 +88,7 @@ class Pool implements ConnectionInterface
             usleep(25 * 1000);
         } while (time() - $startTime < $timeout);
 
-        return false;
+        return null;
     }
 
     /**
@@ -143,14 +140,11 @@ class Pool implements ConnectionInterface
         return $this;
     }
 
-    /**
-     * @return int|false
-     */
-    public function ignore(string $tube)
+    public function ignore(string $tube): ?int
     {
         if (isset($this->watching[$tube])) {
             if (count($this->watching) === 1) {
-                return false;
+                return null;
             }
             $this->collection->sendToAll('ignore', [$tube]);
             unset($this->watching[$tube]);
@@ -170,39 +164,27 @@ class Pool implements ConnectionInterface
         return $job;
     }
 
-    /**
-     * @return array|false
-     */
-    public function peekReady()
+    public function peekReady(): ?array
     {
         return $this->peekStatus('peekReady');
     }
 
-    /**
-     * @return array|false
-     */
-    public function peekDelayed()
+    public function peekDelayed(): ?array
     {
         return $this->peekStatus('peekDelayed');
     }
 
-    /**
-     * @return array|false
-     */
-    public function peekBuried()
+    public function peekBuried(): ?array
     {
         return $this->peekStatus('peekBuried');
     }
 
-    /**
-     * @return array|false
-     */
-    protected function peekStatus(string $command)
+    protected function peekStatus(string $command): ?array
     {
         try {
             $result = $this->collection->sendToOne($command, []);
         } catch (RuntimeException $e) {
-            return false;
+            return null;
         }
         if (isset($result['response']) && is_array($result['response']) && isset($result['response']['id'])) {
             $result['response']['id'] = $this->combineId($result['connection'], (int)$result['response']['id']);
@@ -234,10 +216,7 @@ class Pool implements ConnectionInterface
         return $kicked;
     }
 
-    /**
-     * @return array|false
-     */
-    public function stats()
+    public function stats(): ?array
     {
         $stats = [];
         $onSuccess = function (array $result) use (&$stats): bool {
@@ -250,7 +229,7 @@ class Pool implements ConnectionInterface
         $this->collection->sendToAll('stats', [], $onSuccess);
 
         if (!is_array($stats) || empty($stats)) {
-            return false;
+            return null;
         }
         return $stats;
     }
@@ -267,10 +246,7 @@ class Pool implements ConnectionInterface
         return $job;
     }
 
-    /**
-     * @return array|false
-     */
-    public function statsTube(string $tube)
+    public function statsTube(string $tube): ?array
     {
         $stats = [];
         $onSuccess = function (array $result) use (&$stats): bool {
@@ -283,7 +259,7 @@ class Pool implements ConnectionInterface
         $this->collection->sendToAll('statsTube', [$tube], $onSuccess);
 
         if (!is_array($stats) || empty($stats)) {
-            return false;
+            return null;
         }
         return $stats;
     }

--- a/src/Pool/Collection.php
+++ b/src/Pool/Collection.php
@@ -108,7 +108,7 @@ class Collection implements CollectionInterface
         while (!$keysExhausted && ($key = $this->strategy->pickOne($keysAvailable)) !== false) {
             try {
                 $result = $this->sendToExact($key, $command, $arguments);
-                if ($result['response'] !== false) {
+                if ($result['response'] !== null) {
                     return $result;
                 }
             } catch (RuntimeException $e) {
@@ -243,14 +243,14 @@ class Collection implements CollectionInterface
                 }
                 // ignore
                 $result = [
-                    'response' => false,
+                    'response' => null,
                 ];
             }
 
             $continue = true;
-            if ($result['response'] === false && $failure !== null) {
+            if ($result['response'] === null && $failure !== null) {
                 $continue = call_user_func($failure);
-            } elseif ($result['response'] !== false && $success !== null) {
+            } elseif ($result['response'] !== null && $success !== null) {
                 $continue = call_user_func($success, $result);
             }
 

--- a/tests/Command/ReserveTest.php
+++ b/tests/Command/ReserveTest.php
@@ -54,7 +54,7 @@ class ReserveTest extends CommandTestCase
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn($status);
-        static::assertFalse((new Reserve(123))->process($this->socket));
+        static::assertNull((new Reserve(123))->process($this->socket));
     }
 
     public function failureStatusReturnsFalseDataProvider(): array

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -150,7 +150,7 @@ class ConnectionTest extends TestCase
 
     public function testIgnoreDoesNothingWhenOnlyHasOneTube(): void
     {
-        static::assertFalse($this->beanstalk->ignore('default'));
+        static::assertNull($this->beanstalk->ignore('default'));
     }
 
     public function testPeek(): void
@@ -184,17 +184,17 @@ class ConnectionTest extends TestCase
 
     public function testPeekReadyNotFound(): void
     {
-        static::assertFalse($this->execute('peek-ready', 'NOT_FOUND', 'peekReady'));
+        static::assertNull($this->execute('peek-ready', 'NOT_FOUND', 'peekReady'));
     }
 
     public function testPeekDelayedNotFound(): void
     {
-        static::assertFalse($this->execute('peek-delayed', 'NOT_FOUND', 'peekDelayed'));
+        static::assertNull($this->execute('peek-delayed', 'NOT_FOUND', 'peekDelayed'));
     }
 
     public function testPeekBuriedNotFound(): void
     {
-        static::assertFalse($this->execute('peek-buried', 'NOT_FOUND', 'peekBuried'));
+        static::assertNull($this->execute('peek-buried', 'NOT_FOUND', 'peekBuried'));
     }
 
     public function testKick(): void

--- a/tests/Console/TubePeekCommandTest.php
+++ b/tests/Console/TubePeekCommandTest.php
@@ -158,7 +158,7 @@ class TubePeekCommandTest extends ConsoleTestCase
 
         $this->connection->expects(static::once())
             ->method('peekBuried')
-            ->willReturn(false);
+            ->willReturn(null);
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -74,7 +74,7 @@ class IntegrationPoolTest extends TestCase
     {
         $this->setupTube('integration-test');
         // make sure it's empty
-        $this->beanstalk->peekReady();
+        static::assertNull($this->beanstalk->peekReady());
 
         $data = 'This is my data';
         $id = $this->beanstalk->put($data);
@@ -86,7 +86,7 @@ class IntegrationPoolTest extends TestCase
         $this->beanstalk->touch($jobData['id']);
         $this->beanstalk->delete($jobData['id']);
 
-        static::assertFalse($this->beanstalk->peekReady());
+        static::assertNull($this->beanstalk->peekReady());
     }
 
     public function testBuriedJobProcess(): void

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -70,7 +70,7 @@ class IntegrationTest extends TestCase
     {
         $this->setupTube('integration-test');
         // make sure it's empty
-        $this->beanstalk->peekReady();
+        static::assertNull($this->beanstalk->peekReady());
 
         $data = 'This is my data';
         $id = $this->beanstalk->put($data);
@@ -82,7 +82,7 @@ class IntegrationTest extends TestCase
         $this->beanstalk->touch($jobData['id']);
         $this->beanstalk->delete($jobData['id']);
 
-        static::assertFalse($this->beanstalk->peekReady());
+        static::assertNull($this->beanstalk->peekReady());
     }
 
     public function testBuriedJobProcess(): void

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -17,7 +17,7 @@ class CollectionTest extends TestCase
     private const SEND_COMMANDS_ALLOWED = [
         'useTube' => ['tube', 'self'],
         'put' => ['data', 123],
-        'reserve' => [123, 123],
+        'reserve' => [123, ['some result']],
         'touch' => [123, 'self'],
         'release' => [123, 'self'],
         'bury' => [123, 'self'],
@@ -26,9 +26,9 @@ class CollectionTest extends TestCase
         'ignore' => ['tube', 123],
         'peek' => [123, ['some result']],
         'statsJob' => [123, ['some result']],
-        'peekReady' => ['some result'],
-        'peekDelayed' => ['some result'],
-        'peekBuried' => ['some result'],
+        'peekReady' => [['some result']],
+        'peekDelayed' => [['some result']],
+        'peekBuried' => [['some result']],
         'kick' => [123, 123],
         'statsTube' => ['tube', ['some result']],
         'stats' => [['some result']],
@@ -311,6 +311,9 @@ class CollectionTest extends TestCase
         $calls = 0;
         $callback = function () use (&$calls) {
             $calls++;
+            return [
+                'current-jobs' => 123,
+            ];
         };
 
         $connection1 = $this->getMockConnection('id-123');
@@ -485,13 +488,13 @@ class CollectionTest extends TestCase
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())
             ->method($command)
-            ->willReturn(false);
+            ->willReturn(null);
 
         $identifier2 = 'id-456';
         $connection2 = $this->getMockConnection($identifier2);
         $connection2->expects(static::any())
             ->method($command)
-            ->willReturn(false);
+            ->willReturn(null);
 
         $this->strategy->expects(static::any())
             ->method('pickOne')

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -454,11 +454,17 @@ class CollectionTest extends TestCase
 
     public function testSendToOne(): void
     {
-        $command = 'stats';
+        $command = 'peekReady';
+        $response = [
+            'id' => 123,
+            'body' => 'jobData',
+        ];
+
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::once())
-            ->method($command);
+            ->method($command)
+            ->willReturn($response);
 
         $connection2 = $this->getMockConnection('id-456');
 
@@ -474,7 +480,7 @@ class CollectionTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $command = 'stats';
+        $command = 'peekReady';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())
@@ -497,7 +503,12 @@ class CollectionTest extends TestCase
 
     public function testSendToOneIgnoresErrors(): void
     {
-        $command = 'stats';
+        $command = 'peekReady';
+        $response = [
+            'id' => 123,
+            'body' => 'jobData',
+        ];
+
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())
@@ -508,7 +519,7 @@ class CollectionTest extends TestCase
         $connection2 = $this->getMockConnection($identifier2);
         $connection2->expects(static::once())
             ->method($command)
-            ->willReturn(234);
+            ->willReturn($response);
 
         $this->strategy->expects(static::any())
             ->method('pickOne')
@@ -522,7 +533,7 @@ class CollectionTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $command = 'stats';
+        $command = 'peekReady';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
         $connection1->expects(static::any())

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -78,7 +78,7 @@ class PoolTest extends TestCase
     public function testIgnoreDoesNotAllowLessThanOneWatching(): void
     {
         // 'default' tube is already being watched
-        static::assertFalse($this->pool->ignore('default'));
+        static::assertNull($this->pool->ignore('default'));
     }
 
     public function testIgnore(): void
@@ -153,7 +153,7 @@ class PoolTest extends TestCase
             ->with(static::anything(), 'reserve', [0])
             ->willReturn([
                 'connection' => $connection,
-                'response' => false,
+                'response' => null,
             ]);
         $startTime = time();
         $this->pool->reserve(2);
@@ -212,7 +212,7 @@ class PoolTest extends TestCase
             ->willReturnOnConsecutiveCalls(
                 [
                     'connection' => $connection,
-                    'response' => false, // <-- should ignore this one
+                    'response' => null, // <-- should ignore this one
                 ],
                 [
                     'connection' => $connection,
@@ -348,9 +348,9 @@ class PoolTest extends TestCase
             ->with('peekReady', [])
             ->willReturn([
                 'connection' => null,
-                'response' => false,
+                'response' => null,
             ]);
-        static::assertFalse($this->pool->peekReady());
+        static::assertNull($this->pool->peekReady());
     }
 
     public function testPeekDelayed(): void
@@ -386,9 +386,9 @@ class PoolTest extends TestCase
             ->with('peekDelayed', [])
             ->willReturn([
                 'connection' => null,
-                'response' => false,
+                'response' => null,
             ]);
-        static::assertFalse($this->pool->peekDelayed());
+        static::assertNull($this->pool->peekDelayed());
     }
 
     public function testPeekBuried(): void
@@ -423,7 +423,7 @@ class PoolTest extends TestCase
             ->method('sendToOne')
             ->with('peekBuried', [])
             ->willThrowException(new RuntimeException());
-        static::assertFalse($this->pool->peekBuried());
+        static::assertNull($this->pool->peekBuried());
     }
 
     public function testStats(): void


### PR DESCRIPTION
- Replace 'union false' return types with nullable types.
  - This allows type declarations to be added for the same logic.