### PR TITLE
Deprecate Factory static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Deprecated
+- Factory methods will become instance-based with the same name,
+  in the next major version.
 
 ## [2.0.2] - 2022-09-26
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,22 +65,24 @@ The configuration examples in the command line section are created
 using the factory.
 
 ```php
-use Phlib\Beanstalk\Factory;
+$factory = new \Phlib\Beanstalk\Factory();
 
-$beanstalk = Factory::create('localhost');
+$beanstalk = $factory->create('localhost');
 
-$beanstalk = Factory::createFromArray(['host' => 'localhost']);
-
-$beanstalk = Factory::createFromArray([
-    'server' => ['host' => 'localhost']
+$beanstalk = $factory->createFromArray([
+    'host' => 'localhost',
 ]);
 
-$beanstalk = Factory::createFromArray([
+$beanstalk = $factory->createFromArray([
+    'server' => ['host' => 'localhost'],
+]);
+
+$beanstalk = $factory->createFromArray([
     'servers' => [
         ['host' => '10.0.0.1'],
         ['host' => '10.0.0.2'],
-        ['host' => '10.0.0.3']
-    ]
+        ['host' => '10.0.0.3'],
+    ],
 ]);
 
 ```

--- a/bin/beanstalk
+++ b/bin/beanstalk
@@ -13,8 +13,6 @@ foreach ($autoloadFiles as $autoloadFile) {
 }
 
 // use
-use Symfony\Component\Console\Application;
-use Phlib\ConsoleConfiguration\Helper\ConfigurationHelper;
 use Phlib\Beanstalk\Console\ServerStatsCommand;
 use Phlib\Beanstalk\Console\ServerTubesCommand;
 use Phlib\Beanstalk\Console\JobStatsCommand;
@@ -23,18 +21,23 @@ use Phlib\Beanstalk\Console\JobDeleteCommand;
 use Phlib\Beanstalk\Console\TubePeekCommand;
 use Phlib\Beanstalk\Console\TubeKickCommand;
 use Phlib\Beanstalk\Console\TubeStatsCommand;
+use Phlib\Beanstalk\Factory;
+use Phlib\ConsoleConfiguration\Helper\ConfigurationHelper;
+use Symfony\Component\Console\Application;
+
+$factory = new Factory();
 
 // lets go!
 $application = new Application('beanstalk');
 $application->addCommands([
-    new ServerStatsCommand(),
-    new ServerTubesCommand(),
-    new JobStatsCommand(),
-    new JobPeekCommand(),
-    new JobDeleteCommand(),
-    new TubePeekCommand(),
-    new TubeKickCommand(),
-    new TubeStatsCommand()
+    new ServerStatsCommand($factory),
+    new ServerTubesCommand($factory),
+    new JobStatsCommand($factory),
+    new JobPeekCommand($factory),
+    new JobDeleteCommand($factory),
+    new TubePeekCommand($factory),
+    new TubeKickCommand($factory),
+    new TubeStatsCommand($factory),
 ]);
 
 ConfigurationHelper::initHelper(

--- a/bin/beanstalk
+++ b/bin/beanstalk
@@ -13,6 +13,7 @@ foreach ($autoloadFiles as $autoloadFile) {
 }
 
 // use
+use Phlib\Beanstalk\Connection\ConnectionInterface;
 use Phlib\Beanstalk\Console\ServerStatsCommand;
 use Phlib\Beanstalk\Console\ServerTubesCommand;
 use Phlib\Beanstalk\Console\JobStatsCommand;
@@ -22,22 +23,24 @@ use Phlib\Beanstalk\Console\TubePeekCommand;
 use Phlib\Beanstalk\Console\TubeKickCommand;
 use Phlib\Beanstalk\Console\TubeStatsCommand;
 use Phlib\Beanstalk\Factory;
+use Phlib\Beanstalk\StatsService;
 use Phlib\ConsoleConfiguration\Helper\ConfigurationHelper;
 use Symfony\Component\Console\Application;
 
 $factory = new Factory();
+$statsServiceFactory = fn (ConnectionInterface $beanstalk) => new StatsService($beanstalk);
 
 // lets go!
 $application = new Application('beanstalk');
 $application->addCommands([
-    new ServerStatsCommand($factory),
-    new ServerTubesCommand($factory),
+    new ServerStatsCommand($factory, $statsServiceFactory),
+    new ServerTubesCommand($factory, $statsServiceFactory),
     new JobStatsCommand($factory),
     new JobPeekCommand($factory),
     new JobDeleteCommand($factory),
     new TubePeekCommand($factory),
     new TubeKickCommand($factory),
-    new TubeStatsCommand($factory),
+    new TubeStatsCommand($factory, $statsServiceFactory),
 ]);
 
 ConfigurationHelper::initHelper(

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -15,26 +15,31 @@ use Symfony\Component\Console\Command\Command;
  */
 abstract class AbstractCommand extends Command
 {
+    private Factory $factory;
+
     private ConnectionInterface $beanstalk;
 
     private StatsService $statsService;
 
+    public function __construct(Factory $factory)
+    {
+        $this->factory = $factory;
+
+        parent::__construct();
+    }
+
     protected function getBeanstalk(): ConnectionInterface
     {
         if (!isset($this->beanstalk)) {
-            $config = $this->getHelper('configuration')->fetch();
-            $this->beanstalk = Factory::createFromArray($config);
+            $config = [];
+            // Helper will not be defined in unit tests
+            if ($this->getHelperSet()->has('configuration')) {
+                $config = $this->getHelper('configuration')->fetch();
+            }
+            $this->beanstalk = $this->factory->createFromArrayBC($config);
         }
 
         return $this->beanstalk;
-    }
-
-    /**
-     * @internal This method is not part of the backward-compatibility promise. Used for DI in unit tests.
-     */
-    public function setBeanstalk(ConnectionInterface $beanstalk): void
-    {
-        $this->beanstalk = $beanstalk;
     }
 
     protected function getStatsService(): StatsService

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -6,8 +6,9 @@ namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Connection\ConnectionInterface;
 use Phlib\Beanstalk\Factory;
-use Phlib\Beanstalk\StatsService;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class AbstractCommand
@@ -19,8 +20,6 @@ abstract class AbstractCommand extends Command
 
     private ConnectionInterface $beanstalk;
 
-    private StatsService $statsService;
-
     public function __construct(Factory $factory)
     {
         $this->factory = $factory;
@@ -28,34 +27,20 @@ abstract class AbstractCommand extends Command
         parent::__construct();
     }
 
-    protected function getBeanstalk(): ConnectionInterface
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
-        if (!isset($this->beanstalk)) {
-            $config = [];
-            // Helper will not be defined in unit tests
-            if ($this->getHelperSet()->has('configuration')) {
-                $config = $this->getHelper('configuration')->fetch();
-            }
-            $this->beanstalk = $this->factory->createFromArrayBC($config);
+        $config = [];
+        // Helper will not be defined in unit tests
+        if ($this->getHelperSet()->has('configuration')) {
+            $config = $this->getHelper('configuration')->fetch();
         }
+        $this->beanstalk = $this->factory->createFromArrayBC($config);
 
+        parent::initialize($input, $output);
+    }
+
+    final protected function getBeanstalk(): ConnectionInterface
+    {
         return $this->beanstalk;
-    }
-
-    protected function getStatsService(): StatsService
-    {
-        if (!isset($this->statsService)) {
-            $this->statsService = new StatsService($this->getBeanstalk());
-        }
-
-        return $this->statsService;
-    }
-
-    /**
-     * @internal This method is not part of the backward-compatibility promise. Used for DI in unit tests.
-     */
-    public function setStatsService(StatsService $statsService): void
-    {
-        $this->statsService = $statsService;
     }
 }

--- a/src/Console/AbstractStatsCommand.php
+++ b/src/Console/AbstractStatsCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\Beanstalk\Console;
+
+use Phlib\Beanstalk\Factory;
+use Phlib\Beanstalk\StatsService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractStatsCommand extends AbstractCommand
+{
+    private \Closure $statsServiceFactory;
+
+    private StatsService $statsService;
+
+    final public function __construct(Factory $factory, \Closure $statsServiceFactory)
+    {
+        $this->statsServiceFactory = $statsServiceFactory;
+
+        parent::__construct($factory);
+    }
+
+    final protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+
+        $this->statsService = ($this->statsServiceFactory)($this->getBeanstalk());
+    }
+
+    final protected function getStatsService(): StatsService
+    {
+        return $this->statsService;
+    }
+}

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ServerStatsCommand extends AbstractCommand
+class ServerStatsCommand extends AbstractStatsCommand
 {
     protected function configure(): void
     {

--- a/src/Console/ServerTubesCommand.php
+++ b/src/Console/ServerTubesCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ServerTubesCommand extends AbstractCommand
+class ServerTubesCommand extends AbstractStatsCommand
 {
     protected function configure(): void
     {

--- a/src/Console/TubeStatsCommand.php
+++ b/src/Console/TubeStatsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TubeStatsCommand extends AbstractCommand
+class TubeStatsCommand extends AbstractStatsCommand
 {
     protected function configure(): void
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -17,12 +17,28 @@ use Phlib\Beanstalk\Pool\SelectionStrategyInterface;
  */
 class Factory
 {
+    /**
+     * @deprecated 2.1.0 Static method will be changed to instance-based (with the same name) in the next major version
+     */
     public static function create(string $host, int $port = Socket::DEFAULT_PORT, array $options = []): Connection
+    {
+        return (new static())->createBC($host, $port, $options);
+    }
+
+    public function createBC(string $host, int $port = Socket::DEFAULT_PORT, array $options = []): Connection
     {
         return new Connection(new Socket($host, $port, $options));
     }
 
+    /**
+     * @deprecated 2.1.0 Static method will be changed to instance-based (with the same name) in the next major version
+     */
     public static function createFromArray(array $config): ConnectionInterface
+    {
+        return (new static())->createFromArrayBC($config);
+    }
+
+    public function createFromArrayBC(array $config): ConnectionInterface
     {
         if (array_key_exists('host', $config)) {
             $config = [
@@ -31,14 +47,14 @@ class Factory
         }
 
         if (array_key_exists('server', $config)) {
-            $server = static::normalizeArgs($config['server']);
-            $connection = static::create($server['host'], $server['port'], $server['options']);
+            $server = $this->normalizeArgs($config['server']);
+            $connection = $this->createBC($server['host'], $server['port'], $server['options']);
         } elseif (array_key_exists('servers', $config)) {
             if (!isset($config['strategyClass'])) {
                 $config['strategyClass'] = RoundRobinStrategy::class;
             }
-            $servers = static::createConnections($config['servers']);
-            $strategy = static::createStrategy($config['strategyClass']);
+            $servers = $this->createConnectionsBC($config['servers']);
+            $strategy = $this->createStrategyBC($config['strategyClass']);
             $connection = new Pool(new Collection($servers, $strategy));
         } else {
             throw new InvalidArgumentException('Missing required server(s) configuration');
@@ -48,23 +64,40 @@ class Factory
     }
 
     /**
+     * @deprecated 2.1.0 Static method will be changed to instance-based (with the same name) in the next major version
      * @return Connection[]
      */
     public static function createConnections(array $servers): array
+    {
+        return (new static())->createConnectionsBC($servers);
+    }
+
+    /**
+     * @return Connection[]
+     */
+    public function createConnectionsBC(array $servers): array
     {
         $connections = [];
         foreach ($servers as $server) {
             if (array_key_exists('enabled', $server) && $server['enabled'] === false) {
                 continue;
             }
-            $server = static::normalizeArgs($server);
-            $connection = static::create($server['host'], $server['port'], $server['options']);
+            $server = $this->normalizeArgs($server);
+            $connection = $this->createBC($server['host'], $server['port'], $server['options']);
             $connections[] = $connection;
         }
         return $connections;
     }
 
+    /**
+     * @deprecated 2.1.0 Static method will be changed to instance-based (with the same name) in the next major version
+     */
     public static function createStrategy(string $class): SelectionStrategyInterface
+    {
+        return (new static())->createStrategyBC($class);
+    }
+
+    public function createStrategyBC(string $class): SelectionStrategyInterface
     {
         if (!class_exists($class)) {
             throw new InvalidArgumentException("Specified Pool strategy class '{$class}' does not exist.");
@@ -72,7 +105,7 @@ class Factory
         return new $class();
     }
 
-    private static function normalizeArgs(array $serverArgs): array
+    private function normalizeArgs(array $serverArgs): array
     {
         return $serverArgs + [
             'host' => null,

--- a/tests/Console/ConsoleTestCase.php
+++ b/tests/Console/ConsoleTestCase.php
@@ -5,30 +5,40 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Connection;
+use Phlib\Beanstalk\Factory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class ConsoleTestCase extends TestCase
+abstract class ConsoleTestCase extends TestCase
 {
     protected AbstractCommand $command;
 
     protected CommandTester $commandTester;
 
     /**
+     * @var Factory|MockObject
+     */
+    protected Factory $factory;
+
+    /**
      * @var Connection|MockObject
      */
     protected MockObject $connection;
 
-    protected function setUp(): void
+    final protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
         $this->connection->expects(static::any())
             ->method('getName')
             ->willReturn(sha1(uniqid()));
 
-        $this->command->setBeanstalk($this->connection);
+        $this->factory = $this->createMock(Factory::class);
+        $this->factory->method('createFromArrayBC')
+            ->willReturn($this->connection);
+
+        $this->command = $this->setUpCommand();
 
         $application = new Application();
         $application->add($this->command);
@@ -37,4 +47,6 @@ class ConsoleTestCase extends TestCase
 
         parent::setUp();
     }
+
+    abstract protected function setUpCommand(): AbstractCommand;
 }

--- a/tests/Console/JobDeleteCommandTest.php
+++ b/tests/Console/JobDeleteCommandTest.php
@@ -8,11 +8,9 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class JobDeleteCommandTest extends ConsoleTestCase
 {
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new JobDeleteCommand();
-
-        parent::setUp();
+        return new JobDeleteCommand($this->factory);
     }
 
     public function testDeleteJob(): void

--- a/tests/Console/JobPeekCommandTest.php
+++ b/tests/Console/JobPeekCommandTest.php
@@ -8,11 +8,9 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class JobPeekCommandTest extends ConsoleTestCase
 {
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new JobPeekCommand();
-
-        parent::setUp();
+        return new JobPeekCommand($this->factory);
     }
 
     public function testPeekJob(): void

--- a/tests/Console/JobStatsCommandTest.php
+++ b/tests/Console/JobStatsCommandTest.php
@@ -8,11 +8,9 @@ use Phlib\Beanstalk\Exception\NotFoundException;
 
 class JobStatsCommandTest extends ConsoleTestCase
 {
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new JobStatsCommand();
-
-        parent::setUp();
+        return new JobStatsCommand($this->factory);
     }
 
     public function testJobStats(): void

--- a/tests/Console/ServerStatsCommandTest.php
+++ b/tests/Console/ServerStatsCommandTest.php
@@ -77,12 +77,10 @@ class ServerStatsCommandTest extends ConsoleTestCase
 
     protected function setUpCommand(): AbstractCommand
     {
-        $command = new ServerStatsCommand($this->factory);
-
         $this->statsService = $this->createMock(StatsService::class);
-        $command->setStatsService($this->statsService);
+        $statsServiceFactory = fn () => $this->statsService;
 
-        return $command;
+        return new ServerStatsCommand($this->factory, $statsServiceFactory);
     }
 
     public function testAllStats(): void

--- a/tests/Console/ServerStatsCommandTest.php
+++ b/tests/Console/ServerStatsCommandTest.php
@@ -75,14 +75,14 @@ class ServerStatsCommandTest extends ConsoleTestCase
      */
     private MockObject $statsService;
 
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new ServerStatsCommand();
-
-        parent::setUp();
+        $command = new ServerStatsCommand($this->factory);
 
         $this->statsService = $this->createMock(StatsService::class);
-        $this->command->setStatsService($this->statsService);
+        $command->setStatsService($this->statsService);
+
+        return $command;
     }
 
     public function testAllStats(): void

--- a/tests/Console/ServerTubesCommandTest.php
+++ b/tests/Console/ServerTubesCommandTest.php
@@ -45,12 +45,10 @@ class ServerTubesCommandTest extends ConsoleTestCase
 
     protected function setUpCommand(): AbstractCommand
     {
-        $command = new ServerTubesCommand($this->factory);
-
         $this->statsService = $this->createMock(StatsService::class);
-        $command->setStatsService($this->statsService);
+        $statsServiceFactory = fn () => $this->statsService;
 
-        return $command;
+        return new ServerTubesCommand($this->factory, $statsServiceFactory);
     }
 
     public function testTubeStats(): void

--- a/tests/Console/ServerTubesCommandTest.php
+++ b/tests/Console/ServerTubesCommandTest.php
@@ -43,14 +43,14 @@ class ServerTubesCommandTest extends ConsoleTestCase
      */
     private MockObject $statsService;
 
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new ServerTubesCommand();
-
-        parent::setUp();
+        $command = new ServerTubesCommand($this->factory);
 
         $this->statsService = $this->createMock(StatsService::class);
-        $this->command->setStatsService($this->statsService);
+        $command->setStatsService($this->statsService);
+
+        return $command;
     }
 
     public function testTubeStats(): void

--- a/tests/Console/TubeKickCommandTest.php
+++ b/tests/Console/TubeKickCommandTest.php
@@ -6,11 +6,9 @@ namespace Phlib\Beanstalk\Console;
 
 class TubeKickCommandTest extends ConsoleTestCase
 {
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new TubeKickCommand();
-
-        parent::setUp();
+        return new TubeKickCommand($this->factory);
     }
 
     public function testTubeKick(): void

--- a/tests/Console/TubePeekCommandTest.php
+++ b/tests/Console/TubePeekCommandTest.php
@@ -8,11 +8,9 @@ use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 class TubePeekCommandTest extends ConsoleTestCase
 {
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new TubePeekCommand();
-
-        parent::setUp();
+        return new TubePeekCommand($this->factory);
     }
 
     public function testTubePeekDefault(): void

--- a/tests/Console/TubeStatsCommandTest.php
+++ b/tests/Console/TubeStatsCommandTest.php
@@ -31,14 +31,14 @@ class TubeStatsCommandTest extends ConsoleTestCase
      */
     private MockObject $statsService;
 
-    protected function setUp(): void
+    protected function setUpCommand(): AbstractCommand
     {
-        $this->command = new TubeStatsCommand();
-
-        parent::setUp();
+        $command = new TubeStatsCommand($this->factory);
 
         $this->statsService = $this->createMock(StatsService::class);
-        $this->command->setStatsService($this->statsService);
+        $command->setStatsService($this->statsService);
+
+        return $command;
     }
 
     public function testAllStats(): void

--- a/tests/Console/TubeStatsCommandTest.php
+++ b/tests/Console/TubeStatsCommandTest.php
@@ -33,12 +33,10 @@ class TubeStatsCommandTest extends ConsoleTestCase
 
     protected function setUpCommand(): AbstractCommand
     {
-        $command = new TubeStatsCommand($this->factory);
-
         $this->statsService = $this->createMock(StatsService::class);
-        $command->setStatsService($this->statsService);
+        $statsServiceFactory = fn () => $this->statsService;
 
-        return $command;
+        return new TubeStatsCommand($this->factory, $statsServiceFactory);
     }
 
     public function testAllStats(): void

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -14,7 +14,8 @@ class FactoryTest extends TestCase
 {
     public function testCreate(): void
     {
-        static::assertInstanceOf(ConnectionInterface::class, Factory::create('localhost'));
+        $factory = new Factory();
+        static::assertInstanceOf(ConnectionInterface::class, $factory->createBC('localhost'));
     }
 
     /**
@@ -22,7 +23,8 @@ class FactoryTest extends TestCase
      */
     public function testCreateFromArray($expectedClass, $config): void
     {
-        static::assertInstanceOf($expectedClass, Factory::createFromArray($config));
+        $factory = new Factory();
+        static::assertInstanceOf($expectedClass, $factory->createFromArrayBC($config));
     }
 
     public function createFromArrayDataProvider(): array
@@ -72,11 +74,13 @@ class FactoryTest extends TestCase
             'servers' => [$hostConfig, $hostConfig],
             'strategyClass' => $strategyClass,
         ];
-        $pool = Factory::createFromArray($poolConfig);
-        /* @var $pool Pool */
 
+        $factory = new Factory();
+        /** @var Pool $pool */
+        $pool = $factory->createFromArrayBC($poolConfig);
+
+        /** @var Pool\Collection $collection */
         $collection = $pool->getCollection();
-        /* @var $collection Pool\Collection */
 
         static::assertInstanceOf($strategyClass, $collection->getSelectionStrategy());
     }
@@ -100,14 +104,17 @@ class FactoryTest extends TestCase
             'servers' => [$hostConfig, $hostConfig],
             'strategyClass' => '\Some\RandomClass\ThatDoesnt\Exist',
         ];
-        Factory::createFromArray($poolConfig);
+
+        $factory = new Factory();
+        $factory->createFromArrayBC($poolConfig);
     }
 
     public function testCreateFromArrayFailsWhenEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Factory::createFromArray([]);
+        $factory = new Factory();
+        $factory->createFromArrayBC([]);
     }
 
     public function testCreateConnections(): void
@@ -117,7 +124,8 @@ class FactoryTest extends TestCase
             'host' => 'locahost',
         ];
 
-        $connections = Factory::createConnections([$config, $config, $config]);
+        $factory = new Factory();
+        $connections = $factory->createConnectionsBC([$config, $config, $config]);
         foreach ($connections as $connection) {
             $result = $result && $connection instanceof Connection;
         }


### PR DESCRIPTION
- Change Factory to instance methods.
  - Keep static methods for BC until the next major version.
- Pass Factory as a dependency to the console commands.
  - Removes the need to inject the connection using a hack method, now being able to use a mock Factory instead.
- Pass StatsService as a dependency to the console commands.
  - Removes the need to inject the StatsService using a hack method.