### PR TITLE
Clear root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Pass the same parameters directly to `Connection`.
 - **BC break**: Move core `ConnectionInterface` up to package root namespace.
 - **BC break**: Deprecated static Factory methods are now instance-based.
-- **BC break**: Move `ValidateTrait` out of the root namespace.
+- **BC break**: Move `ValidateTrait` and `StatsService` out of root namespace.
   No impact to standard use of this package.
 ### Removed
 - **BC break**: Remove `Socket::getUniqueIdentifier()` and `Socket::connect()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Pass the same parameters directly to `Connection`.
 - **BC break**: Move core `ConnectionInterface` up to package root namespace.
 - **BC break**: Deprecated static Factory methods are now instance-based.
+- **BC break**: Move `ValidateTrait` out of the root namespace.
+  No impact to standard use of this package.
 ### Removed
 - **BC break**: Remove `Socket::getUniqueIdentifier()` and `Socket::connect()`
   only needed internally.

--- a/bin/beanstalk
+++ b/bin/beanstalk
@@ -29,7 +29,7 @@ use Phlib\Beanstalk\Console\TubeKickCommand;
 use Phlib\Beanstalk\Console\TubePeekCommand;
 use Phlib\Beanstalk\Console\TubeStatsCommand;
 use Phlib\Beanstalk\Factory;
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use Phlib\ConsoleConfiguration\Helper\ConfigurationHelper;
 use Symfony\Component\Console\Application;
 

--- a/src/Command/Bury.php
+++ b/src/Command/Bury.php
@@ -7,7 +7,6 @@ namespace Phlib\Beanstalk\Command;
 use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\CommandException;
 use Phlib\Beanstalk\Exception\NotFoundException;
-use Phlib\Beanstalk\ValidateTrait;
 
 /**
  * @package Phlib\Beanstalk

--- a/src/Command/Ignore.php
+++ b/src/Command/Ignore.php
@@ -6,7 +6,6 @@ namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\CommandException;
-use Phlib\Beanstalk\ValidateTrait;
 
 /**
  * @package Phlib\Beanstalk

--- a/src/Command/Put.php
+++ b/src/Command/Put.php
@@ -8,7 +8,6 @@ use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\BuriedException;
 use Phlib\Beanstalk\Exception\CommandException;
 use Phlib\Beanstalk\Exception\DrainingException;
-use Phlib\Beanstalk\ValidateTrait;
 
 /**
  * @package Phlib\Beanstalk

--- a/src/Command/Release.php
+++ b/src/Command/Release.php
@@ -8,7 +8,6 @@ use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\BuriedException;
 use Phlib\Beanstalk\Exception\CommandException;
 use Phlib\Beanstalk\Exception\NotFoundException;
-use Phlib\Beanstalk\ValidateTrait;
 
 /**
  * @package Phlib\Beanstalk

--- a/src/Command/StatsTube.php
+++ b/src/Command/StatsTube.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phlib\Beanstalk\Command;
 
-use Phlib\Beanstalk\ValidateTrait;
-
 /**
  * @package Phlib\Beanstalk
  */

--- a/src/Command/UseTube.php
+++ b/src/Command/UseTube.php
@@ -6,7 +6,6 @@ namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\CommandException;
-use Phlib\Beanstalk\ValidateTrait;
 
 /**
  * @package Phlib\Beanstalk

--- a/src/Command/ValidateTrait.php
+++ b/src/Command/ValidateTrait.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phlib\Beanstalk;
+namespace Phlib\Beanstalk\Command;
 
+use Phlib\Beanstalk\ConnectionInterface;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
 
 /**

--- a/src/Command/Watch.php
+++ b/src/Command/Watch.php
@@ -6,7 +6,6 @@ namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\CommandException;
-use Phlib\Beanstalk\ValidateTrait;
 
 /**
  * @package Phlib\Beanstalk

--- a/src/Console/AbstractStatsCommand.php
+++ b/src/Console/AbstractStatsCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Factory;
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Console/ServerTubesCommand.php
+++ b/src/Console/ServerTubesCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phlib\Beanstalk\Console;
 
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;

--- a/src/Stats/Service.php
+++ b/src/Stats/Service.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Phlib\Beanstalk;
+namespace Phlib\Beanstalk\Stats;
+
+use Phlib\Beanstalk\ConnectionInterface;
 
 /**
  * @package Phlib\Beanstalk
  */
-class StatsService
+class Service
 {
     public const SERVER_BINLOG = 1;
 

--- a/tests/Command/ValidateTraitTest.php
+++ b/tests/Command/ValidateTraitTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phlib\Beanstalk;
+namespace Phlib\Beanstalk\Command;
 
+use Phlib\Beanstalk\ConnectionInterface;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Console/ServerStatsCommandTest.php
+++ b/tests/Console/ServerStatsCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ServerStatsCommandTest extends ConsoleTestCase

--- a/tests/Console/ServerTubesCommandTest.php
+++ b/tests/Console/ServerTubesCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phlib\Beanstalk\Console;
 
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ServerTubesCommandTest extends ConsoleTestCase

--- a/tests/Console/TubeStatsCommandTest.php
+++ b/tests/Console/TubeStatsCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Phlib\Beanstalk\StatsService;
+use Phlib\Beanstalk\Stats\Service as StatsService;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class TubeStatsCommandTest extends ConsoleTestCase

--- a/tests/Stats/ServiceTest.php
+++ b/tests/Stats/ServiceTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phlib\Beanstalk;
+namespace Phlib\Beanstalk\Stats;
 
+use Phlib\Beanstalk\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -144,7 +145,7 @@ class StatsServiceTest extends TestCase
      */
     private Connection $connection;
 
-    private StatsService $statsService;
+    private Service $statsService;
 
     protected function setUp(): void
     {
@@ -153,7 +154,7 @@ class StatsServiceTest extends TestCase
             ->method('getName')
             ->willReturn(sha1(uniqid()));
 
-        $this->statsService = new StatsService($this->connection);
+        $this->statsService = new Service($this->connection);
 
         parent::setUp();
     }
@@ -189,10 +190,10 @@ class StatsServiceTest extends TestCase
     public function dataGetServerStats(): array
     {
         return [
-            'binlog' => [StatsService::SERVER_BINLOG, self::STATS_KEY_BINLOG],
-            'command' => [StatsService::SERVER_COMMAND, self::STATS_KEY_COMMAND],
-            'current' => [StatsService::SERVER_CURRENT, self::STATS_KEY_CURRENT],
-            'all' => [StatsService::SERVER_ALL, array_merge(self::STATS_KEY_BINLOG, self::STATS_KEY_COMMAND, self::STATS_KEY_CURRENT)],
+            'binlog' => [Service::SERVER_BINLOG, self::STATS_KEY_BINLOG],
+            'command' => [Service::SERVER_COMMAND, self::STATS_KEY_COMMAND],
+            'current' => [Service::SERVER_CURRENT, self::STATS_KEY_CURRENT],
+            'all' => [Service::SERVER_ALL, array_merge(self::STATS_KEY_BINLOG, self::STATS_KEY_COMMAND, self::STATS_KEY_CURRENT)],
         ];
     }
 


### PR DESCRIPTION
* Move `ValidateTrait` and `StatsService` out of the root namespace.
  * Leaves only the expected primary classes in the root for package implementations.