### PR TITLE
Remove nullable return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `useTube()`, `touch()`, `release()`, `bury()`, `delete()`
     have void return type.
 - Status is a required argument for the `tube:peek` CLI command.
+- **BC break**: Change `Collection::getConnection()` to throw
+  `InvalidArgumentException` instead of `NotFoundException` if the given
+  connection key does not exist in the pool.
 - **BC break**: Constructor for `Connection` no longer needs a `Socket`.
   Pass the same parameters directly to `Connection`.
 - **BC break**: Move core `ConnectionInterface` up to package root namespace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add new `DrainingException` thrown by `put()` when the server is in draining
   mode and cannot accept new jobs.
   Previously this threw `CommandException` which the new exception extends.
+- Add constants with standardised codes and messages for `NotFoundException`.
 ### Changed
 - Update commands to better reflect the protocol:
   - `watch()` returns integer of number of watched tubes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Status is a required argument for the `tube:peek` CLI command.
 - **BC break**: `reserve()` throws `NotFoundException` if no jobs available,
   rather than return null.
+- **BC break**: `peekBuried()`, `peekDelayed()` & `peekReady()` throw
+  `NotFoundException` if there are no matching jobs, rather than return null.
 - **BC break**: Change `Collection::getConnection()` to throw
   `InvalidArgumentException` instead of `NotFoundException` if the given
   connection key does not exist in the pool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `useTube()`, `touch()`, `release()`, `bury()`, `delete()`
     have void return type.
 - Status is a required argument for the `tube:peek` CLI command.
+- **BC break**: `reserve()` throws `NotFoundException` if no jobs available,
+  rather than return null.
 - **BC break**: Change `Collection::getConnection()` to throw
   `InvalidArgumentException` instead of `NotFoundException` if the given
   connection key does not exist in the pool.

--- a/src/Command/Bury.php
+++ b/src/Command/Bury.php
@@ -42,7 +42,10 @@ class Bury implements CommandInterface
                 return;
 
             case 'NOT_FOUND':
-                throw new NotFoundException("Job id '{$this->id}' could not be found.");
+                throw new NotFoundException(
+                    sprintf(NotFoundException::JOB_ID_MSG_F, $this->id),
+                    NotFoundException::JOB_ID_CODE,
+                );
 
             default:
                 throw new CommandException("Bury id '{$this->id}' failed '{$response}'");

--- a/src/Command/Delete.php
+++ b/src/Command/Delete.php
@@ -35,7 +35,10 @@ class Delete implements CommandInterface
                 return;
 
             case 'NOT_FOUND':
-                throw new NotFoundException("Job id '{$this->id}' could not be found.");
+                throw new NotFoundException(
+                    sprintf(NotFoundException::JOB_ID_MSG_F, $this->id),
+                    NotFoundException::JOB_ID_CODE,
+                );
 
             default:
                 throw new CommandException("Delete id '{$this->id}' failed '{$response}'");

--- a/src/Command/Peek.php
+++ b/src/Command/Peek.php
@@ -42,7 +42,16 @@ class Peek implements CommandInterface
                 ];
 
             case 'NOT_FOUND':
-                throw new NotFoundException('Peek failed to find any jobs');
+                if (isset($this->jobId)) {
+                    throw new NotFoundException(
+                        sprintf(NotFoundException::JOB_ID_MSG_F, $this->jobId),
+                        NotFoundException::JOB_ID_CODE,
+                    );
+                }
+                throw new NotFoundException(
+                    NotFoundException::PEEK_STATUS_MSG,
+                    NotFoundException::PEEK_STATUS_CODE,
+                );
 
             default:
                 throw new CommandException("Unknown peek response '{$response}'");

--- a/src/Command/Release.php
+++ b/src/Command/Release.php
@@ -48,7 +48,10 @@ class Release implements CommandInterface
             case 'BURIED':
                 throw BuriedException::create($this->id);
             case 'NOT_FOUND':
-                throw new NotFoundException("Job id '{$this->id}' could not be found.");
+                throw new NotFoundException(
+                    sprintf(NotFoundException::JOB_ID_MSG_F, $this->id),
+                    NotFoundException::JOB_ID_CODE,
+                );
             default:
                 throw new CommandException("Release '{$this->id}' failed '{$response}'");
         }

--- a/src/Command/Reserve.php
+++ b/src/Command/Reserve.php
@@ -6,6 +6,7 @@ namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 
 /**
  * @package Phlib\Beanstalk
@@ -45,7 +46,10 @@ class Reserve implements CommandInterface
 
             case 'DEADLINE_SOON':
             case 'TIMED_OUT':
-                return null;
+                throw new NotFoundException(
+                    NotFoundException::RESERVE_NO_JOBS_AVAILABLE_MSG,
+                    NotFoundException::RESERVE_NO_JOBS_AVAILABLE_CODE,
+                );
 
             default:
                 throw new CommandException("Reserve failed '{$status}'");

--- a/src/Command/StatsTrait.php
+++ b/src/Command/StatsTrait.php
@@ -23,7 +23,10 @@ trait StatsTrait
                 return $this->decode($data);
 
             case 'NOT_FOUND':
-                throw new NotFoundException('Stats read could not find specified job');
+                throw new NotFoundException(
+                    NotFoundException::STATS_MSG,
+                    NotFoundException::STATS_CODE,
+                );
 
             default:
                 throw new CommandException("Stats read failed '{$status}'");

--- a/src/Command/Touch.php
+++ b/src/Command/Touch.php
@@ -35,7 +35,10 @@ class Touch implements CommandInterface
                 return;
 
             case 'NOT_TOUCHED':
-                throw new NotFoundException("Job id '{$this->id}' could not be found.");
+                throw new NotFoundException(
+                    sprintf(NotFoundException::JOB_ID_MSG_F, $this->id),
+                    NotFoundException::JOB_ID_CODE,
+                );
 
             default:
                 throw new CommandException("Touch id '{$this->id}' failed '{$status}'");

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -7,7 +7,6 @@ namespace Phlib\Beanstalk;
 use Phlib\Beanstalk\Connection\Socket;
 use Phlib\Beanstalk\Exception\CommandException;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Phlib\Beanstalk\Exception\NotFoundException;
 
 /**
  * @package Phlib\Beanstalk
@@ -157,29 +156,25 @@ class Connection implements ConnectionInterface
             ->process($this->socket);
     }
 
-    public function peekReady(): ?array
+    public function peekReady(): array
     {
         return $this->peekStatus(Command\PeekStatus::READY);
     }
 
-    public function peekDelayed(): ?array
+    public function peekDelayed(): array
     {
         return $this->peekStatus(Command\PeekStatus::DELAYED);
     }
 
-    public function peekBuried(): ?array
+    public function peekBuried(): array
     {
         return $this->peekStatus(Command\PeekStatus::BURIED);
     }
 
-    private function peekStatus(string $status): ?array
+    private function peekStatus(string $status): array
     {
-        try {
-            return (new Command\PeekStatus($status))
-                ->process($this->socket);
-        } catch (NotFoundException $e) {
-            return null;
-        }
+        return (new Command\PeekStatus($status))
+            ->process($this->socket);
     }
 
     public function kick(int $quantity): int

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -71,7 +71,7 @@ class Connection implements ConnectionInterface
             ->process($this->socket);
     }
 
-    public function reserve(?int $timeout = null): ?array
+    public function reserve(?int $timeout = null): array
     {
         $jobData = (new Command\Reserve($timeout))
             ->process($this->socket);

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -77,14 +77,24 @@ interface ConnectionInterface
 
     /**
      * @param string|int $id
+     * @throws NotFoundException when the job cannot be found
      */
     public function peek($id): array;
 
-    public function peekReady(): ?array;
+    /**
+     * @throws NotFoundException when no jobs to peek in the 'ready' status
+     */
+    public function peekReady(): array;
 
-    public function peekDelayed(): ?array;
+    /**
+     * @throws NotFoundException when no jobs to peek in the 'delayed' status
+     */
+    public function peekDelayed(): array;
 
-    public function peekBuried(): ?array;
+    /**
+     * @throws NotFoundException when no jobs to peek in the 'buried' status
+     */
+    public function peekBuried(): array;
 
     public function kick(int $quantity): int;
 

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phlib\Beanstalk;
 
+use Phlib\Beanstalk\Exception\NotFoundException;
+
 /**
  * @package Phlib\Beanstalk
  */
@@ -41,7 +43,10 @@ interface ConnectionInterface
         int $ttr = self::DEFAULT_TTR
     );
 
-    public function reserve(?int $timeout = null): ?array;
+    /**
+     * @throws NotFoundException when no jobs available to reserve within timeout
+     */
+    public function reserve(?int $timeout = null): array;
 
     /**
      * @param string|int $id

--- a/src/Console/TubePeekCommand.php
+++ b/src/Console/TubePeekCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,25 +47,24 @@ class TubePeekCommand extends AbstractCommand
         $this->getBeanstalk()
             ->useTube($input->getArgument('tube'));
 
-        // Use switch instead of `->{'peek' . $status}` to allow static analysis
-        switch ($status) {
-            case 'ready':
-                $job = $this->getBeanstalk()->peekReady();
-                break;
-            case 'delayed':
-                $job = $this->getBeanstalk()->peekDelayed();
-                break;
-            case 'buried':
-                $job = $this->getBeanstalk()->peekBuried();
-                break;
-            default:
-                throw new InvalidArgumentException("Specified status '{$status}' is not valid.");
-        }
-
-        if ($job === null) {
-            $output->writeln("No jobs found in '{$status}' status.");
-        } else {
+        try {
+            // Use switch instead of `->{'peek' . $status}` to allow static analysis
+            switch ($status) {
+                case 'ready':
+                    $job = $this->getBeanstalk()->peekReady();
+                    break;
+                case 'delayed':
+                    $job = $this->getBeanstalk()->peekDelayed();
+                    break;
+                case 'buried':
+                    $job = $this->getBeanstalk()->peekBuried();
+                    break;
+                default:
+                    throw new InvalidArgumentException("Specified status '{$status}' is not valid");
+            }
             $this->displayJob($job, $output);
+        } catch (NotFoundException $e) {
+            $output->writeln("No jobs found in '{$status}' status.");
         }
 
         return 0;

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -5,8 +5,31 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Exception;
 
 /**
+ * The `NOT_FOUND` response is defined in the protocol for the following commands:
+ *   - reserve-job
+ *   - delete
+ *   - release
+ *   - bury
+ *   - touch
+ *   - peek
+ *   - kick-job
+ *   - stats-job
+ *   - stats-tube
+ *   - pause-tube
+ *
  * @package Phlib\Beanstalk
  */
 class NotFoundException extends \Exception implements Exception
 {
+    public const JOB_ID_CODE = 1;
+
+    public const JOB_ID_MSG_F = 'Job id \'%s\' could not be found';
+
+    public const STATS_CODE = 2;
+
+    public const STATS_MSG = 'Stats could not be found for the given entity';
+
+    public const PEEK_STATUS_CODE = 3;
+
+    public const PEEK_STATUS_MSG = 'Peek failed to find any jobs for the given status';
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -32,4 +32,8 @@ class NotFoundException extends \Exception implements Exception
     public const PEEK_STATUS_CODE = 3;
 
     public const PEEK_STATUS_MSG = 'Peek failed to find any jobs for the given status';
+
+    public const RESERVE_NO_JOBS_AVAILABLE_CODE = 4;
+
+    public const RESERVE_NO_JOBS_AVAILABLE_MSG = 'No jobs available to reserve';
 }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -167,29 +167,25 @@ class Pool implements ConnectionInterface
         return $job;
     }
 
-    public function peekReady(): ?array
+    public function peekReady(): array
     {
         return $this->peekStatus('peekReady');
     }
 
-    public function peekDelayed(): ?array
+    public function peekDelayed(): array
     {
         return $this->peekStatus('peekDelayed');
     }
 
-    public function peekBuried(): ?array
+    public function peekBuried(): array
     {
         return $this->peekStatus('peekBuried');
     }
 
-    private function peekStatus(string $command): ?array
+    private function peekStatus(string $command): array
     {
-        try {
-            $result = $this->collection->sendToOne($command, []);
-        } catch (RuntimeException $e) {
-            return null;
-        }
-        if (isset($result['response']) && is_array($result['response']) && isset($result['response']['id'])) {
+        $result = $this->collection->sendToOne($command, []);
+        if (is_array($result['response']) && isset($result['response']['id'])) {
             $result['response']['id'] = $this->combineId($result['connection'], (int)$result['response']['id']);
         }
         return $result['response'];

--- a/src/Pool/Collection.php
+++ b/src/Pool/Collection.php
@@ -7,7 +7,6 @@ namespace Phlib\Beanstalk\Pool;
 use Phlib\Beanstalk\ConnectionInterface;
 use Phlib\Beanstalk\Exception\Exception as BeanstalkException;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\RuntimeException;
 
 /**
@@ -58,7 +57,7 @@ class Collection implements CollectionInterface
     public function getConnection(string $key): ConnectionInterface
     {
         if (!array_key_exists($key, $this->connections)) {
-            throw new NotFoundException("Specified key '{$key}' is not in the pool.");
+            throw new InvalidArgumentException("Specified key '{$key}' is not in the pool.");
         }
         $retryAt = $this->connections[$key]['retry_at'];
         if ($retryAt !== false && $retryAt > time()) {

--- a/src/Pool/Collection.php
+++ b/src/Pool/Collection.php
@@ -7,6 +7,7 @@ namespace Phlib\Beanstalk\Pool;
 use Phlib\Beanstalk\ConnectionInterface;
 use Phlib\Beanstalk\Exception\Exception as BeanstalkException;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\RuntimeException;
 
 /**
@@ -87,28 +88,25 @@ class Collection implements CollectionInterface
      */
     public function sendToOne(string $command, array $arguments = [])
     {
-        $e = null;
-
         $keysAvailable = array_keys($this->connections);
         shuffle($keysAvailable);
         foreach ($keysAvailable as $key) {
             try {
-                $result = $this->sendToExact($key, $command, $arguments);
-                if ($result['response'] !== null) {
-                    return $result;
-                }
-            } catch (RuntimeException $e) {
+                return $this->sendToExact($key, $command, $arguments);
+            } catch (NotFoundException | RuntimeException $e) {
                 // ignore
             }
         }
 
-        $message = "Failed to send command '{$command}' to one of the connections.";
-        if ($e instanceof \Exception) {
-            $final = new RuntimeException($message, 0, $e);
-        } else {
-            $final = new RuntimeException($message);
+        if (isset($e) && $e instanceof NotFoundException) {
+            throw $e;
         }
-        throw $final;
+
+        throw new RuntimeException(
+            "Failed to send command '{$command}' to one of the connections.",
+            0,
+            $e ?? null,
+        );
     }
 
     public function sendToExact(string $key, string $command, array $arguments = []): array

--- a/tests/Command/BuryTest.php
+++ b/tests/Command/BuryTest.php
@@ -34,12 +34,16 @@ class BuryTest extends CommandTestCase
 
     public function testNotFoundThrowsException(): void
     {
+        $jobId = rand();
+
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(NotFoundException::JOB_ID_MSG_F, $jobId));
+        $this->expectExceptionCode(NotFoundException::JOB_ID_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('NOT_FOUND');
-        (new Bury(123, 123))->process($this->socket);
+        (new Bury($jobId, 123))->process($this->socket);
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/Command/DeleteTest.php
+++ b/tests/Command/DeleteTest.php
@@ -32,12 +32,16 @@ class DeleteTest extends CommandTestCase
 
     public function testNotFoundThrowsException(): void
     {
+        $jobId = rand();
+
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(NotFoundException::JOB_ID_MSG_F, $jobId));
+        $this->expectExceptionCode(NotFoundException::JOB_ID_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('NOT_FOUND');
-        (new Delete(123))->process($this->socket);
+        (new Delete($jobId))->process($this->socket);
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/Command/PeekStatusTest.php
+++ b/tests/Command/PeekStatusTest.php
@@ -59,6 +59,8 @@ class PeekStatusTest extends CommandTestCase
     public function testNotFoundThrowsException(): void
     {
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')

--- a/tests/Command/PeekTest.php
+++ b/tests/Command/PeekTest.php
@@ -36,12 +36,16 @@ class PeekTest extends CommandTestCase
 
     public function testNotFoundThrowsException(): void
     {
+        $jobId = rand();
+
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(NotFoundException::JOB_ID_MSG_F, $jobId));
+        $this->expectExceptionCode(NotFoundException::JOB_ID_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('NOT_FOUND');
-        (new Peek(10))->process($this->socket);
+        (new Peek($jobId))->process($this->socket);
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/Command/ReleaseTest.php
+++ b/tests/Command/ReleaseTest.php
@@ -53,12 +53,16 @@ class ReleaseTest extends CommandTestCase
 
     public function testNotFoundThrowsException(): void
     {
+        $jobId = rand();
+
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(NotFoundException::JOB_ID_MSG_F, $jobId));
+        $this->expectExceptionCode(NotFoundException::JOB_ID_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('NOT_FOUND');
-        (new Release(123, 456, 789))->process($this->socket);
+        (new Release($jobId, 456, 789))->process($this->socket);
     }
 
     public function testBuriedThrowsException(): void

--- a/tests/Command/ReserveTest.php
+++ b/tests/Command/ReserveTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Command;
 
 use Phlib\Beanstalk\Exception\CommandException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 
 class ReserveTest extends CommandTestCase
 {
@@ -46,17 +47,21 @@ class ReserveTest extends CommandTestCase
     }
 
     /**
-     * @dataProvider failureStatusReturnsFalseDataProvider
+     * @dataProvider dataFailureStatus
      */
-    public function testFailureStatusReturnsFalse(string $status): void
+    public function testFailureStatus(string $status): void
     {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::RESERVE_NO_JOBS_AVAILABLE_MSG);
+        $this->expectExceptionCode(NotFoundException::RESERVE_NO_JOBS_AVAILABLE_CODE);
+
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn($status);
-        static::assertNull((new Reserve(123))->process($this->socket));
+        (new Reserve(123))->process($this->socket);
     }
 
-    public function failureStatusReturnsFalseDataProvider(): array
+    public function dataFailureStatus(): array
     {
         return [
             'timeout' => ['TIMED_OUT'],

--- a/tests/Command/StatsTraitTest.php
+++ b/tests/Command/StatsTraitTest.php
@@ -13,6 +13,8 @@ class StatsTraitTest extends CommandTestCase
     public function testWhenStatusNotFound(): void
     {
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::STATS_MSG);
+        $this->expectExceptionCode(NotFoundException::STATS_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')

--- a/tests/Command/TouchTest.php
+++ b/tests/Command/TouchTest.php
@@ -32,12 +32,16 @@ class TouchTest extends CommandTestCase
 
     public function testErrorThrowsException(): void
     {
+        $jobId = rand();
+
         $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(NotFoundException::JOB_ID_MSG_F, $jobId));
+        $this->expectExceptionCode(NotFoundException::JOB_ID_CODE);
 
         $this->socket->expects(static::any())
             ->method('read')
             ->willReturn('NOT_TOUCHED');
-        (new Touch(123))->process($this->socket);
+        (new Touch($jobId))->process($this->socket);
     }
 
     public function testUnknownStatusThrowsException(): void

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -235,10 +235,13 @@ class ConnectionTest extends TestCase
 
     public function testPeekNotFound(): void
     {
-        $this->expectException(NotFoundException::class);
+        $jobId = rand();
 
-        $id = 245;
-        static::assertFalse($this->execute("peek {$id}", 'NOT_FOUND', 'peek', [$id]));
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(NotFoundException::JOB_ID_MSG_F, $jobId));
+        $this->expectExceptionCode(NotFoundException::JOB_ID_CODE);
+
+        $this->execute("peek {$jobId}", 'NOT_FOUND', 'peek', [$jobId]);
     }
 
     public function testPeekReadyNotFound(): void

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -246,17 +246,29 @@ class ConnectionTest extends TestCase
 
     public function testPeekReadyNotFound(): void
     {
-        static::assertNull($this->execute('peek-ready', 'NOT_FOUND', 'peekReady'));
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
+        $this->execute('peek-ready', 'NOT_FOUND', 'peekReady');
     }
 
     public function testPeekDelayedNotFound(): void
     {
-        static::assertNull($this->execute('peek-delayed', 'NOT_FOUND', 'peekDelayed'));
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
+        $this->execute('peek-delayed', 'NOT_FOUND', 'peekDelayed');
     }
 
     public function testPeekBuriedNotFound(): void
     {
-        static::assertNull($this->execute('peek-buried', 'NOT_FOUND', 'peekBuried'));
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
+        $this->execute('peek-buried', 'NOT_FOUND', 'peekBuried');
     }
 
     public function testKick(): void

--- a/tests/Console/JobDeleteCommandTest.php
+++ b/tests/Console/JobDeleteCommandTest.php
@@ -33,14 +33,16 @@ class JobDeleteCommandTest extends ConsoleTestCase
 
     public function testJobNotFound(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $jobId = rand();
+        $message = sha1(uniqid('xMsg'));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage($message);
 
         $this->connection->expects(static::once())
             ->method('delete')
             ->with($jobId)
-            ->willThrowException(new NotFoundException('job not found'));
+            ->willThrowException(new NotFoundException($message));
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),

--- a/tests/Console/JobPeekCommandTest.php
+++ b/tests/Console/JobPeekCommandTest.php
@@ -38,14 +38,16 @@ class JobPeekCommandTest extends ConsoleTestCase
 
     public function testJobNotFound(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $jobId = rand();
+        $message = sha1(uniqid('xMsg'));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage($message);
 
         $this->connection->expects(static::once())
             ->method('peek')
             ->with($jobId)
-            ->willThrowException(new NotFoundException('job not found'));
+            ->willThrowException(new NotFoundException($message));
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),

--- a/tests/Console/JobStatsCommandTest.php
+++ b/tests/Console/JobStatsCommandTest.php
@@ -64,14 +64,16 @@ class JobStatsCommandTest extends ConsoleTestCase
 
     public function testJobNotFound(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $jobId = rand();
+        $message = sha1(uniqid('xMsg'));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage($message);
 
         $this->connection->expects(static::once())
             ->method('statsJob')
             ->with($jobId)
-            ->willThrowException(new NotFoundException('job not found'));
+            ->willThrowException(new NotFoundException($message));
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),

--- a/tests/Console/TubePeekCommandTest.php
+++ b/tests/Console/TubePeekCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 
 class TubePeekCommandTest extends ConsoleTestCase
 {
@@ -127,7 +128,10 @@ class TubePeekCommandTest extends ConsoleTestCase
 
         $this->connection->expects(static::once())
             ->method('peekBuried')
-            ->willReturn(null);
+            ->willThrowException(new NotFoundException(
+                NotFoundException::PEEK_STATUS_MSG,
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -86,21 +86,40 @@ class IntegrationPoolTest extends TestCase
 
     public function testFullJobProcess(): void
     {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
         $this->setupTube('integration-test');
-        // make sure it's empty
-        static::assertNull($this->beanstalk->peekReady());
+
+        try {
+            // make sure it's empty
+            $this->beanstalk->peekReady();
+            static::fail('peekReady should have no jobs');
+        } catch (NotFoundException $e) {
+            // expected response
+        }
 
         $data = 'This is my data';
         $id = $this->beanstalk->put($data);
-        $jobData = $this->beanstalk->reserve();
 
+        try {
+            $peek = $this->beanstalk->peekReady();
+        } catch (NotFoundException $e) {
+            // Job should have been found
+            static::fail('peekReady should show the job after touch');
+        }
+        static::assertSame($id, $peek['id']);
+        static::assertSame($data, $peek['body']);
+
+        $jobData = $this->beanstalk->reserve();
         static::assertSame($id, $jobData['id']);
         static::assertSame($data, $jobData['body']);
 
         $this->beanstalk->touch($jobData['id']);
         $this->beanstalk->delete($jobData['id']);
 
-        static::assertNull($this->beanstalk->peekReady());
+        $this->beanstalk->peekReady();
     }
 
     public function testBuriedJobProcess(): void

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -162,7 +162,8 @@ class CollectionTest extends TestCase
 
     public function testForUnknownConnection(): void
     {
-        $this->expectException(NotFoundException::class);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not in the pool');
 
         $collection = new Collection([$this->getMockConnection('id-123')]);
         $collection->getConnection('foo-bar');

--- a/tests/Pool/CollectionTest.php
+++ b/tests/Pool/CollectionTest.php
@@ -480,22 +480,61 @@ class CollectionTest extends TestCase
         $collection->sendToOne($command);
     }
 
-    public function testSendToOneWhenAllConnectionsAreUsed(): void
+    public function testSendToOneIgnoresNotFound(): void
     {
-        $this->expectException(RuntimeException::class);
+        $command = 'peekReady';
+        $response = [
+            'id' => 123,
+            'body' => 'jobData',
+        ];
+
+        $identifier1 = 'id-123';
+        $connection1 = $this->getMockConnection($identifier1);
+        $connection1->expects(static::once())
+            ->method($command)
+            ->willThrowException(new NotFoundException(
+                NotFoundException::PEEK_STATUS_MSG,
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
+
+        $identifier2 = 'id-456';
+        $connection2 = $this->getMockConnection($identifier2);
+        $connection2->expects(static::once())
+            ->method($command)
+            ->willReturn($response);
+
+        $collection = new Collection([$connection1, $connection2]);
+        $actual = $collection->sendToOne($command);
+
+        static::assertSame($response, $actual['response']);
+    }
+
+    public function testSendToOneThrowsTheLastNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('error2');
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
 
         $command = 'peekReady';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
-        $connection1->expects(static::any())
+        $connection1->expects(static::once())
             ->method($command)
-            ->willReturn(null);
+            ->willThrowException(new NotFoundException(
+                // Deliberate non-standard message to track which exception is returned
+                'error1',
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
 
         $identifier2 = 'id-456';
         $connection2 = $this->getMockConnection($identifier2);
-        $connection2->expects(static::any())
+        $connection2->expects(static::once())
             ->method($command)
-            ->willReturn(null);
+            ->willThrowException(new NotFoundException(
+                // Deliberate non-standard message to track which exception is returned
+                'error2',
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
 
         $collection = new Collection([$connection1, $connection2]);
         $collection->sendToOne($command);
@@ -511,7 +550,7 @@ class CollectionTest extends TestCase
 
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
-        $connection1->expects(static::any())
+        $connection1->expects(static::once())
             ->method($command)
             ->willThrowException(new RuntimeException());
 
@@ -528,11 +567,12 @@ class CollectionTest extends TestCase
     public function testSendToOneThrowsTheLastError(): void
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to send command');
 
         $command = 'peekReady';
         $identifier1 = 'id-123';
         $connection1 = $this->getMockConnection($identifier1);
-        $connection1->expects(static::any())
+        $connection1->expects(static::once())
             ->method($command)
             ->willThrowException(new RuntimeException('error1'));
 
@@ -549,6 +589,23 @@ class CollectionTest extends TestCase
             $previous = $e->getPrevious();
             static::assertInstanceOf(RuntimeException::class, $previous);
             static::assertSame('error2', $previous->getMessage());
+            throw $e;
+        }
+    }
+
+    public function testSendToOneThrowsExceptionWhenNoAvailableConnections(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to send command');
+
+        $command = 'peekReady';
+
+        try {
+            $collection = new Collection([]);
+            $collection->sendToOne($command);
+        } catch (RuntimeException $e) {
+            $previous = $e->getPrevious();
+            static::assertNull($previous);
             throw $e;
         }
     }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -6,6 +6,7 @@ namespace Phlib\Beanstalk;
 
 use Phlib\Beanstalk\Exception\CommandException;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
+use Phlib\Beanstalk\Exception\NotFoundException;
 use Phlib\Beanstalk\Exception\RuntimeException;
 use Phlib\Beanstalk\Pool\Collection;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -134,17 +135,20 @@ class PoolTest extends TestCase
             static::markTestSkipped('Timing test skipped');
         }
 
-        $connection = $this->createMockConnection('host:123');
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::RESERVE_NO_JOBS_AVAILABLE_MSG);
+        $this->expectExceptionCode(NotFoundException::RESERVE_NO_JOBS_AVAILABLE_CODE);
+
         $this->collection->expects(static::any())
             ->method('getAvailableKeys')
             ->willReturn(['host:123', 'host:456']);
         $this->collection->expects(static::any())
             ->method('sendToExact')
             ->with(static::anything(), 'reserve', [0])
-            ->willReturn([
-                'connection' => $connection,
-                'response' => null,
-            ]);
+            ->willThrowException(new NotFoundException(
+                NotFoundException::RESERVE_NO_JOBS_AVAILABLE_MSG,
+                NotFoundException::RESERVE_NO_JOBS_AVAILABLE_CODE,
+            ));
         $startTime = time();
         $this->pool->reserve(2);
         $totalTime = time() - $startTime;
@@ -199,16 +203,19 @@ class PoolTest extends TestCase
         $this->collection->expects(static::exactly(2))
             ->method('sendToExact')
             ->with(static::anything(), 'reserve', [0])
-            ->willReturnOnConsecutiveCalls(
-                [
-                    'connection' => $connection,
-                    'response' => null, // <-- should ignore this one
-                ],
-                [
+            ->willReturnCallback(function () use ($connection, $response) {
+                static $count = 0;
+                if ($count++ === 0) {
+                    throw new NotFoundException(
+                        NotFoundException::RESERVE_NO_JOBS_AVAILABLE_MSG,
+                        NotFoundException::RESERVE_NO_JOBS_AVAILABLE_CODE,
+                    );
+                }
+                return [
                     'connection' => $connection,
                     'response' => $response,
-                ]
-            );
+                ];
+            });
         static::assertSame($expected, $this->pool->reserve());
     }
 

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -340,14 +340,19 @@ class PoolTest extends TestCase
 
     public function testPeekReadyWithNoReadyJobs(): void
     {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
         $this->collection->expects(static::any())
             ->method('sendToOne')
             ->with('peekReady', [])
-            ->willReturn([
-                'connection' => null,
-                'response' => null,
-            ]);
-        static::assertNull($this->pool->peekReady());
+            ->willThrowException(new NotFoundException(
+                NotFoundException::PEEK_STATUS_MSG,
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
+
+        $this->pool->peekReady();
     }
 
     public function testPeekDelayed(): void
@@ -378,14 +383,19 @@ class PoolTest extends TestCase
 
     public function testPeekDelayedWithNoDelayedJobs(): void
     {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
         $this->collection->expects(static::any())
             ->method('sendToOne')
             ->with('peekDelayed', [])
-            ->willReturn([
-                'connection' => null,
-                'response' => null,
-            ]);
-        static::assertNull($this->pool->peekDelayed());
+            ->willThrowException(new NotFoundException(
+                NotFoundException::PEEK_STATUS_MSG,
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
+
+        $this->pool->peekDelayed();
     }
 
     public function testPeekBuried(): void
@@ -416,11 +426,19 @@ class PoolTest extends TestCase
 
     public function testPeekBuriedWithNoBuriedJobs(): void
     {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(NotFoundException::PEEK_STATUS_MSG);
+        $this->expectExceptionCode(NotFoundException::PEEK_STATUS_CODE);
+
         $this->collection->expects(static::any())
             ->method('sendToOne')
             ->with('peekBuried', [])
-            ->willThrowException(new RuntimeException());
-        static::assertNull($this->pool->peekBuried());
+            ->willThrowException(new NotFoundException(
+                NotFoundException::PEEK_STATUS_MSG,
+                NotFoundException::PEEK_STATUS_CODE,
+            ));
+
+        $this->pool->peekBuried();
     }
 
     public function testStats(): void


### PR DESCRIPTION
- Use `NotFoundException` when commands are unable to find the given entity, rather than return null. This gives a clearer response that can be more easily filtered out as a Pool iterates the connections.
- Collection stops using NotFound for a connection key that's not present.