### PR TITLE
Stats draining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add new `DrainingException` thrown by `put()` when the server is in draining
   mode and cannot accept new jobs.
   Previously this threw `CommandException` which the new exception extends.
+- Add draining status to the `server:stats` CLI command.
 - Add constants with standardised codes and messages for `NotFoundException`.
 ### Changed
 - Update commands to better reflect the protocol:

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -6,11 +6,10 @@ namespace Phlib\Beanstalk\Console;
 
 use Phlib\Beanstalk\Console\Service\StatsService;
 use Phlib\Beanstalk\Exception\InvalidArgumentException;
-use Symfony\Component\Console\Helper\FormatterHelper;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @package Phlib\Beanstalk
@@ -31,10 +30,15 @@ class ServerStatsCommand extends AbstractStatsCommand
         $stat = $input->getOption('stat');
         $service = $this->getStatsService();
 
-        $this->outputDetectedConfig($output);
+        $io = new SymfonyStyle($input, $output);
+
+        if ($output->isVerbose()) {
+            $this->outputDetectedConfig($io);
+        }
+
         if (empty($stat)) {
-            $this->outputInfo($service, $output);
-            $this->outputStats($service, $output);
+            $this->outputInfo($service, $io);
+            $this->outputStats($service, $io);
         } else {
             $this->outputStat($service, $stat, $output);
         }
@@ -42,49 +46,36 @@ class ServerStatsCommand extends AbstractStatsCommand
         return 0;
     }
 
-    private function outputDetectedConfig(OutputInterface $output): void
+    private function outputDetectedConfig(SymfonyStyle $io): void
     {
-        if (!$output->isVerbose()) {
-            return;
-        }
         $configPath = $this->getHelper('configuration')->getConfigPath();
         if ($configPath === '[default]') {
             $configPath = '[default fallback localhost]';
         }
 
-        $output->writeln('Configuration: ' . $configPath);
+        $io->comment('Configuration: ' . $configPath);
     }
 
-    private function outputInfo(StatsService $stats, OutputInterface $output): void
+    private function outputInfo(StatsService $stats, SymfonyStyle $io): void
     {
         $info = $stats->getServerInfo();
 
-        /** @var FormatterHelper $formatter */
-        $formatter = $this->getHelper('formatter');
-        $block = $formatter->formatBlock(
-            [
-                "Host: {$info['hostname']} (pid {$info['pid']})",
-                "Beanstalk Version: {$info['version']}",
-                "Resources: uptime/{$info['uptime']}, connections/{$info['total-connections']}",
-                "Jobs: total/{$info['total-jobs']}, timeouts/{$info['job-timeouts']}",
-            ],
-            'info',
-            true
+        $io->section('Server Information');
+        $io->definitionList(
+            ['Host' => sprintf('%s (pid %d)', $info['hostname'], $info['pid'])],
+            ['Beanstalk Version' => $info['version']],
+            ['Resources' => sprintf('uptime/%d, connections/%d', $info['uptime'], $info['total-connections'])],
+            ['Jobs' => sprintf('total/%d, timeouts/%d', $info['total-jobs'], $info['job-timeouts'])],
         );
-
-        $output->writeln('<info>Server Information</info>');
-        $output->writeln($block);
     }
 
-    private function outputStats(StatsService $stats, OutputInterface $output): void
+    private function outputStats(StatsService $stats, SymfonyStyle $io): void
     {
         $binlog = $stats->getServerStats(StatsService::SERVER_BINLOG);
         $command = $stats->getServerStats(StatsService::SERVER_COMMAND);
         $current = $stats->getServerStats(StatsService::SERVER_CURRENT);
 
-        $table = new Table($output);
-        $table->setStyle('borderless');
-        $table->setHeaders(['Current', 'Stat', 'Command', 'Stat', 'Binlog', 'Stat']);
+        $headers = ['Current', 'Stat', 'Command', 'Stat', 'Binlog', 'Stat'];
 
         $binlogKeys = array_keys($binlog);
         $binlogValues = array_values($binlog);
@@ -93,6 +84,7 @@ class ServerStatsCommand extends AbstractStatsCommand
         $currentKeys = array_keys($current);
         $currentValues = array_values($current);
 
+        $rows = [];
         $maxRows = max(count($binlog), count($command), count($current));
         for ($i = 0; $i < $maxRows; $i++) {
             $row = [
@@ -103,11 +95,11 @@ class ServerStatsCommand extends AbstractStatsCommand
                 $binlogKeys[$i] ?? '',
                 $binlogValues[$i] ?? '',
             ];
-            $table->addRow($row);
+            $rows[] = $row;
         }
 
-        $output->writeln('<info>Server Statistics</info>');
-        $table->render();
+        $io->section('Server Statistics');
+        $io->table($headers, $rows);
     }
 
     private function outputStat(StatsService $service, string $stat, OutputInterface $output): void

--- a/src/Console/ServerStatsCommand.php
+++ b/src/Console/ServerStatsCommand.php
@@ -60,12 +60,18 @@ class ServerStatsCommand extends AbstractStatsCommand
     {
         $info = $stats->getServerInfo();
 
+        $draining = $info['draining'];
+        if ($draining === 'true') {
+            $draining = sprintf('<error>%s</>', $draining);
+        }
+
         $io->section('Server Information');
         $io->definitionList(
             ['Host' => sprintf('%s (pid %d)', $info['hostname'], $info['pid'])],
             ['Beanstalk Version' => $info['version']],
             ['Resources' => sprintf('uptime/%d, connections/%d', $info['uptime'], $info['total-connections'])],
             ['Jobs' => sprintf('total/%d, timeouts/%d', $info['total-jobs'], $info['job-timeouts'])],
+            ['Draining' => $draining],
         );
     }
 

--- a/src/Console/Service/StatsService.php
+++ b/src/Console/Service/StatsService.php
@@ -34,17 +34,18 @@ class StatsService
     ];
 
     private const INFO_KEYS = [
-        'pid',
-        'hostname',
-        'id',
-        'version',
-        'uptime',
-        'total-jobs',
         'job-timeouts',
+        'total-jobs',
         'max-job-size',
         'total-connections',
+        'pid',
+        'version',
         'rusage-utime',
         'rusage-stime',
+        'uptime',
+        'draining',
+        'id',
+        'hostname',
     ];
 
     private const SERVER_KEYS = [

--- a/src/Model/Stats.php
+++ b/src/Model/Stats.php
@@ -5,6 +5,67 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Model;
 
 /**
+ * Stats keys are defined in the protocol as the response to the `stats` command.
+ * The `stats-tube` command uses a subset as marked, plus some additional keys described below.
+ *   - current-jobs-urgent [&stats-tube]
+ *   - current-jobs-ready [&stats-tube]
+ *   - current-jobs-reserved [&stats-tube]
+ *   - current-jobs-delayed [&stats-tube]
+ *   - current-jobs-buried [&stats-tube]
+ *   - cmd-put
+ *   - cmd-peek
+ *   - cmd-peek-ready
+ *   - cmd-peek-delayed
+ *   - cmd-peek-buried
+ *   - cmd-reserve
+ *   - cmd-reserve-with-timeout
+ *   - cmd-touch
+ *   - cmd-use
+ *   - cmd-watch
+ *   - cmd-ignore
+ *   - cmd-delete [&stats-tube]
+ *   - cmd-release
+ *   - cmd-bury
+ *   - cmd-kick
+ *   - cmd-stats
+ *   - cmd-stats-job
+ *   - cmd-stats-tube
+ *   - cmd-list-tubes
+ *   - cmd-list-tube-used
+ *   - cmd-list-tubes-watched
+ *   - cmd-pause-tube [&stats-tube]
+ *   - job-timeouts
+ *   - total-jobs [&stats-tube]
+ *   - max-job-size
+ *   - current-tubes
+ *   - current-connections
+ *   - current-producers
+ *   - current-workers
+ *   - current-waiting [&stats-tube]
+ *   - total-connections
+ *   - pid
+ *   - version
+ *   - rusage-utime
+ *   - rusage-stime
+ *   - uptime
+ *   - binlog-oldest-index
+ *   - binlog-current-index
+ *   - binlog-max-size
+ *   - binlog-records-written
+ *   - binlog-records-migrated
+ *   - draining
+ *   - id
+ *   - hostname
+ *   - os
+ *   - platform
+ *
+ * Only present in response to `stats-tube`:
+ *   - name
+ *   - current-using
+ *   - current-watching
+ *   - pause
+ *   - pause-time-left
+ *
  * @package Phlib\Beanstalk
  */
 class Stats
@@ -12,14 +73,18 @@ class Stats
     private const LIST_STATS = [
         'pid',
         'version',
-        'hostname',
-        'name',
         'uptime',
         'binlog-current-index',
+        'draining',
+        'id',
+        'hostname',
+        'os',
+        'platform',
+        'name',
     ];
 
     private const MAX_STATS = [
-        'timeouts',
+        'max-job-size',
         'binlog-max-size',
         'binlog-oldest-index',
     ];

--- a/tests/Console/ServerStatsCommandTest.php
+++ b/tests/Console/ServerStatsCommandTest.php
@@ -104,20 +104,39 @@ class ServerStatsCommandTest extends ConsoleTestCase
         $output = $this->commandTester->getDisplay();
 
         // Headers
-        static::assertStringContainsString(
-            'Host: ' . self::STATS_INFO['hostname'] . ' (pid ' . self::STATS_INFO['pid'] . ')',
+        static::assertMatchesRegularExpression(
+            sprintf(
+                "|%s\\s+%s \(pid %d\)|",
+                'Host',
+                self::STATS_INFO['hostname'],
+                self::STATS_INFO['pid']
+            ),
             $output
         );
-        static::assertStringContainsString(
-            'Beanstalk Version: ' . self::STATS_INFO['version'],
+        static::assertMatchesRegularExpression(
+            sprintf(
+                '|%s\\s+%s|',
+                'Beanstalk Version',
+                self::STATS_INFO['version']
+            ),
             $output
         );
-        static::assertStringContainsString(
-            'Resources: uptime/' . self::STATS_INFO['uptime'] . ', connections/' . self::STATS_INFO['total-connections'],
+        static::assertMatchesRegularExpression(
+            sprintf(
+                '|%s\\s+uptime/%d, connections/%d|',
+                'Resources',
+                self::STATS_INFO['uptime'],
+                self::STATS_INFO['total-connections']
+            ),
             $output
         );
-        static::assertStringContainsString(
-            'Jobs: total/' . self::STATS_INFO['total-jobs'] . ', timeouts/' . self::STATS_INFO['job-timeouts'],
+        static::assertMatchesRegularExpression(
+            sprintf(
+                '|%s\\s+total/%d, timeouts/%d|',
+                'Jobs',
+                self::STATS_INFO['total-jobs'],
+                self::STATS_INFO['job-timeouts']
+            ),
             $output
         );
 

--- a/tests/Console/ServerStatsCommandTest.php
+++ b/tests/Console/ServerStatsCommandTest.php
@@ -20,6 +20,7 @@ class ServerStatsCommandTest extends ConsoleTestCase
         'rusage-utime' => 326.282258,
         'rusage-stime' => 1082.901991,
         'uptime' => 440851,
+        'draining' => 'true',
         'id' => '541ced2bff508923',
         'hostname' => 'test-host.local',
     ];
@@ -136,6 +137,14 @@ class ServerStatsCommandTest extends ConsoleTestCase
                 'Jobs',
                 self::STATS_INFO['total-jobs'],
                 self::STATS_INFO['job-timeouts']
+            ),
+            $output
+        );
+        static::assertMatchesRegularExpression(
+            sprintf(
+                '|%s\\s+%s|',
+                'Draining',
+                self::STATS_INFO['draining'],
             ),
             $output
         );

--- a/tests/Console/Service/StatsServiceTest.php
+++ b/tests/Console/Service/StatsServiceTest.php
@@ -74,6 +74,7 @@ class StatsServiceTest extends TestCase
         'rusage-utime',
         'rusage-stime',
         'uptime',
+        'draining',
         'id',
         'hostname',
     ];

--- a/tests/Model/StatsTest.php
+++ b/tests/Model/StatsTest.php
@@ -11,14 +11,18 @@ class StatsTest extends TestCase
     private const LIST_STATS = [
         'pid',
         'version',
-        'hostname',
-        'name',
         'uptime',
         'binlog-current-index',
+        'draining',
+        'id',
+        'hostname',
+        'os',
+        'platform',
+        'name',
     ];
 
     private const MAX_STATS = [
-        'timeouts',
+        'max-job-size',
         'binlog-max-size',
         'binlog-oldest-index',
     ];
@@ -26,7 +30,7 @@ class StatsTest extends TestCase
     public function testToArrayReturnsOriginalData(): void
     {
         $data = [
-            'timeouts' => rand(),
+            'job-timeouts' => rand(),
             'binlog-max-size' => rand(),
         ];
         $stats = new Stats($data);
@@ -42,7 +46,7 @@ class StatsTest extends TestCase
     public function testIsEmptyWithData(): void
     {
         $stats = new Stats([
-            'timeouts' => rand(),
+            'job-timeouts' => rand(),
             'binlog-max-size' => rand(),
         ]);
         static::assertFalse($stats->isEmpty());


### PR DESCRIPTION
- Add draining status to the `server:stats` CLI command.
  - Fixes #10 
- Fix issue with string data being treated as numeric in the Stats model.