### PR TITLE
Managed reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The backward compatibility promise has the following exceptions:
 * Units of code that are annotated with `@internal`.
 
 ## [Unreleased]
+### Added
+- Replay tube selections when reconnecting a failed Pool connection.
 
 ## [3.0.1] - 2023-10-14
 ### Changed

--- a/src/Pool/ManagedConnection.php
+++ b/src/Pool/ManagedConnection.php
@@ -241,6 +241,16 @@ class ManagedConnection implements ConnectionInterface
 
     private function replayTubes(): void
     {
+        $this->logger->debug(
+            sprintf('Replay tube selections for connection \'%s\'', $this->getName()),
+            [
+                'connectionName' => $this->getName(),
+                'using' => $this->using,
+                'watching' => array_keys($this->watching),
+                'ignoring' => array_keys($this->ignoring),
+            ]
+        );
+
         $this->connection->useTube($this->using);
 
         foreach (array_keys($this->watching) as $watchTube) {

--- a/tests/Pool/ManagedConnectionTest.php
+++ b/tests/Pool/ManagedConnectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Beanstalk\Pool;
 
 use ColinODell\PsrTestLogger\TestLogger;
+use Phlib\Beanstalk\Connection;
 use Phlib\Beanstalk\ConnectionInterface;
 use Phlib\Beanstalk\Exception\RuntimeException;
 use phpmock\phpunit\PHPMock;
@@ -207,5 +208,77 @@ class ManagedConnectionTest extends TestCase
         foreach (self::COMMAND_PASS_THROUGH as $command => $map) {
             yield $command => [$command, $map];
         }
+    }
+
+    public function testConnectionGetsRestored(): void
+    {
+        $useTube = sha1(uniqid('use'));
+        $watchTube = sha1(uniqid('watch'));
+        $ignoreTube = Connection::DEFAULT_TUBE;
+        $jobId = rand();
+
+        $releaseCalled = false;
+
+        $this->connection->expects(static::exactly(2))
+            ->method('useTube')
+            ->with($useTube)
+            ->willReturnCallback(function () use (&$releaseCalled) {
+                if ($releaseCalled) {
+                    // This should be called its second time to re-select, before the primary command is called
+                    self::fail('Command was called before connection was reinitialised');
+                }
+            });
+
+        $this->connection->expects(static::exactly(2))
+            ->method('watch')
+            ->with($watchTube)
+            ->willReturnCallback(function () use (&$releaseCalled) {
+                if ($releaseCalled) {
+                    // This should be called its second time to re-select, before the primary command is called
+                    self::fail('Command was called before connection was reinitialised');
+                }
+                return 1;
+            });
+
+        $this->connection->expects(static::exactly(2))
+            ->method('ignore')
+            ->with($ignoreTube)
+            ->willReturnCallback(function () use (&$releaseCalled) {
+                if ($releaseCalled) {
+                    // This should be called its second time to re-select, before the primary command is called
+                    self::fail('Command was called before connection was reinitialised');
+                }
+                return 1;
+            });
+
+        // Force a connection error so it is treated as unavailable
+        $this->connection->expects(static::once())
+            ->method('stats')
+            ->willThrowException(new RuntimeException('connection error'));
+
+        // Command should only be called on the connection after the tube selections are replayed
+        $this->connection->expects(static::once())
+            ->method('release')
+            ->willReturnCallback(function (int $withJobId) use (&$releaseCalled, $jobId): void {
+                $releaseCalled = true;
+                static::assertSame($jobId, $withJobId);
+            });
+
+        $managed = new ManagedConnection($this->connection, 0);
+
+        // Make the tube selections that should be repeated after failure
+        $managed->useTube($useTube);
+        $managed->watch($watchTube);
+        $managed->ignore($ignoreTube);
+
+        try {
+            // Trigger the connection error
+            $managed->stats();
+        } catch (RuntimeException $e) {
+            // ignore
+        }
+
+        // Call the command that should trigger the reinitialisation
+        $managed->release($jobId);
     }
 }


### PR DESCRIPTION
- Replay tube selections when resetting a ManagedConnection.

(Pulled in from ng branch).

Plan to hold this change until after #3 is live in v3 to limit the behaviour changes – keeping the connection behaviour the same through all the refactoring.