### PR TITLE
Add Pool connection retry delay for failed useTube command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The backward compatibility promise has the following exceptions:
 * Units of code that are annotated with `@internal`.
 
 ## [Unreleased]
+### Fixed
+- Add a retry delay to a Pool connection when `useTube()` fails.
 
 ## [3.0.1] - 2023-10-14
 ### Changed

--- a/src/Pool/ManagedConnection.php
+++ b/src/Pool/ManagedConnection.php
@@ -54,7 +54,9 @@ class ManagedConnection implements ConnectionInterface
 
     public function useTube(string $tube): void
     {
-        $this->connection->useTube($tube);
+        $this->tryCommand(
+            fn() => $this->connection->useTube($tube)
+        );
     }
 
     public function put(


### PR DESCRIPTION
Partial fix for #38 . Full solution will be #37 .

As the server wasn't being delayed for a retry, the scenario in #38 of calling `useTube()` immediately followed by `put()` allowed the job to be put to a server that should have been marked as failed.

Using `tryCommand` will mark the server as failed, and the subsequent `put()` will not choose the server which did not accept the `useTube` command.