### PR TITLE
PHP 8.4 deprecation warnings

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -32,7 +32,7 @@ class Connection implements ConnectionInterface
         string $host,
         int $port = Socket::DEFAULT_PORT,
         array $options = [],
-        \Closure $createSocket = null
+        ?\Closure $createSocket = null
     ) {
         if (isset($createSocket)) {
             $this->socket = $createSocket($host, $port, $options);

--- a/src/Connection/Socket.php
+++ b/src/Connection/Socket.php
@@ -79,7 +79,7 @@ class Socket
         }
     }
 
-    public function read(int $length = null): string
+    public function read(?int $length = null): string
     {
         $this->connect();
 

--- a/src/Exception/BuriedException.php
+++ b/src/Exception/BuriedException.php
@@ -13,7 +13,7 @@ class BuriedException extends CommandException
 
     private int $jobId;
 
-    public function __construct(int $jobId, string $message, int $code = 0, \Exception $previous = null)
+    public function __construct(int $jobId, string $message, int $code = 0, ?\Exception $previous = null)
     {
         $this->jobId = $jobId;
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
This fixes several deprecation warnings thrown by this library when running on PHP 8.4 with `E_DEPRECATED` reporting enabled
```
PHP Deprecated:  Phlib\Beanstalk\Connection\Socket::read(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in ./src/Connection/Socket.php on line 82
PHP Deprecated:  Phlib\Beanstalk\Exception\BuriedException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in ./src/Exception/BuriedException.php on line 16
PHP Deprecated:  Phlib\Beanstalk\Connection::__construct(): Implicitly marking parameter $createSocket as nullable is deprecated, the explicit nullable type must be used instead in ./src/Connection.php on line 31
```